### PR TITLE
Create complete Sudaka League esports-style frontend (vanilla HTML/CSS/JS)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,29 +1,157 @@
-const WHATSAPP_PES6 = "https://chat.whatsapp.com/DvRyA2bxAC67x0ulPQYvCa?mode=gi_t";
-const WHATSAPP_SF =
-"https://chat.whatsapp.com/DvRyA2bxAC67x0ulPQYvCa?mode=gi_t";
+const WHATSAPP_PES6 = "https://...";
+const WHATSAPP_SF = "https://...";
+const WHATSAPP_COMUNIDAD = "https://...";
 
-document.getElementById("btn-pes6").href = WHATSAPP_PES6;
-document.getElementById("btn-sf").href = WHATSAPP_SF;
+const overlay = document.getElementById("modal-overlay");
+const modals = [...document.querySelectorAll(".league-modal")];
+const triggers = [...document.querySelectorAll(".league-card")];
+const closeButtons = [...document.querySelectorAll(".close-btn")];
+const copyButtons = [...document.querySelectorAll(".copy-btn")];
+const backToTopButton = document.getElementById("back-to-top");
 
-document.querySelectorAll(".liga-card").forEach(card => {
-    card.addEventListener("click", () => {
-        document.getElementById(card.dataset.panel).classList.remove("hidden");
-    });
+let activeModal = null;
+let lastFocusedElement = null;
+
+// Asignación centralizada de links editables.
+function applyWhatsAppLinks() {
+  const links = {
+    "cta-comunidad": WHATSAPP_COMUNIDAD,
+    "wa-pes6": WHATSAPP_PES6,
+    "wa-pes6-modal": WHATSAPP_PES6,
+    "wa-sf": WHATSAPP_SF,
+    "wa-sf-modal": WHATSAPP_SF
+  };
+
+  Object.entries(links).forEach(([id, value]) => {
+    const element = document.getElementById(id);
+    if (element) element.href = value;
+  });
+}
+
+function getFocusableElements(container) {
+  return [...container.querySelectorAll('button, [href], textarea, details, summary, [tabindex]:not([tabindex="-1"])')]
+    .filter((element) => !element.hasAttribute("disabled"));
+}
+
+function trapFocus(event) {
+  if (event.key !== "Tab" || !activeModal) return;
+
+  const focusable = getFocusableElements(activeModal);
+  if (focusable.length === 0) return;
+
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault();
+    last.focus();
+    return;
+  }
+
+  if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
+function openModal(modalId) {
+  const modal = document.getElementById(modalId);
+  if (!modal) return;
+
+  modals.forEach((item) => item.hidden = true);
+  overlay.hidden = false;
+  modal.hidden = false;
+  activeModal = modal;
+  document.body.classList.add("no-scroll");
+  lastFocusedElement = document.activeElement;
+
+  const initialFocusable = getFocusableElements(modal)[0];
+  if (initialFocusable) initialFocusable.focus();
+}
+
+function closeModal() {
+  if (!activeModal) return;
+
+  activeModal.hidden = true;
+  overlay.hidden = true;
+  document.body.classList.remove("no-scroll");
+  const toFocus = lastFocusedElement;
+  activeModal = null;
+
+  if (toFocus && typeof toFocus.focus === "function") {
+    toFocus.focus();
+  }
+}
+
+triggers.forEach((trigger) => {
+  trigger.addEventListener("click", () => openModal(trigger.dataset.target));
+  trigger.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      openModal(trigger.dataset.target);
+    }
+  });
 });
 
-document.querySelectorAll(".close").forEach(btn => {
-    btn.addEventListener("click", () => {
-        btn.parentElement.classList.add("hidden");
-    });
+closeButtons.forEach((button) => {
+  button.addEventListener("click", closeModal);
 });
 
-document.querySelectorAll(".copy").forEach(btn => {
-    btn.addEventListener("click", () => {
-        const id = btn.dataset.copy;
-        navigator.clipboard.writeText(document.getElementById(id).value);
-        btn.textContent = "✔ Copiado";
-        setTimeout(() => btn.textContent = "📋 Copiar mensaje", 1500);
-    });
+overlay.addEventListener("click", (event) => {
+  if (event.target === overlay) closeModal();
 });
 
-document.getElementById("top").onclick = () => window.scrollTo({ top: 0, behavior: "smooth" });
+window.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") closeModal();
+  trapFocus(event);
+});
+
+async function copyText(text) {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(text);
+    return true;
+  }
+
+  const hiddenTextArea = document.createElement("textarea");
+  hiddenTextArea.value = text;
+  hiddenTextArea.style.position = "fixed";
+  hiddenTextArea.style.opacity = "0";
+  document.body.appendChild(hiddenTextArea);
+  hiddenTextArea.focus();
+  hiddenTextArea.select();
+
+  const success = document.execCommand("copy");
+  document.body.removeChild(hiddenTextArea);
+  return success;
+}
+
+copyButtons.forEach((button) => {
+  button.addEventListener("click", async () => {
+    const targetId = button.dataset.copyTarget;
+    const textarea = document.getElementById(targetId);
+    if (!textarea) return;
+
+    const originalText = button.textContent;
+
+    try {
+      const copied = await copyText(textarea.value);
+      button.textContent = copied ? "✅ Copiado" : "⚠️ No se pudo copiar";
+    } catch (error) {
+      button.textContent = "⚠️ No se pudo copiar";
+    }
+
+    setTimeout(() => {
+      button.textContent = originalText;
+    }, 1800);
+  });
+});
+
+window.addEventListener("scroll", () => {
+  backToTopButton.classList.toggle("visible", window.scrollY > 360);
+});
+
+backToTopButton.addEventListener("click", () => {
+  window.scrollTo({ top: 0, behavior: "smooth" });
+});
+
+applyWhatsAppLinks();

--- a/index.html
+++ b/index.html
@@ -1,143 +1,216 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <title>Sudaka League</title>
-    <link rel="stylesheet" href="styles.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sudaka League</title>
+  <meta name="description" content="Sudaka League - Comunidad de juegos retro online con formato competitivo." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&family=Orbitron:wght@600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
+  <div class="bg-effects" aria-hidden="true"></div>
 
-<header class="hero">
+  <header class="hero section" id="inicio">
+    <p class="hero-kicker">Liga Oficial Retro Competitiva</p>
     <h1>SUDAKA LEAGUE</h1>
-    <p class="subtitulo">Comunidad de juegos retro online con formato competitivo</p>
-    <p class="hero-text">
-        Jugá clásicos como PES 6 y Street Fighter II en ligas organizadas, 
-        sin horarios fijos y coordinando partidas por WhatsApp
+    <p class="subtitle">Comunidad de juegos retro online con formato competitivo</p>
+    <p class="hero-copy">
+      Jugá clásicos como PES 6 y Street Fighter II en ligas organizadas,
+      sin horarios fijos y coordinando partidas por WhatsApp
     </p>
-    <div class="hero-btns">
-        <a href="#" class="btn primary">Unirme a la comunidad</a>
-        <a href="#ligas" class="btn secondary">Ver ligas</a>
+    <div class="hero-actions">
+      <a id="cta-comunidad" class="btn btn-primary" href="#" target="_blank" rel="noopener noreferrer">Unirme a la comunidad</a>
+      <a class="btn btn-secondary" href="#ligas">Ver ligas</a>
     </div>
-</header>
+  </header>
 
-<section class="what-is">
-    <h2>¿QUÉ ES SUDAKA LEAGUE?</h2>
-    <p>Sudaka League es una comunidad de juegos retro online llevados a un formato competitivo. 
-    No hay horarios fijos: los partidos se juegan cuando coinciden dos jugadores disponibles. 
-    La coordinación se realiza por WhatsApp y los resultados cuentan para tablas, ascensos y posiciones.</p>
-</section>
+  <main>
+    <section class="section panel-section hud-separator" aria-labelledby="que-es-title">
+      <h2 id="que-es-title">¿QUÉ ES SUDAKA LEAGUE?</h2>
+      <p>
+        Sudaka League es una comunidad de juegos retro online llevados a un formato competitivo. No hay horarios fijos:
+        los partidos se juegan cuando coinciden dos jugadores disponibles. La coordinación se realiza por WhatsApp y los
+        resultados cuentan para tablas, ascensos y posiciones.
+      </p>
+    </section>
 
-<section id="ligas" class="ligas">
-    <h2>LIGAS</h2>
-    <div class="cards">
-
-        <div class="card" data-target="pes6-panel">
-            <img src="https://via.placeholder.com/400x200?text=PES+6+Infinity+Patch" alt="PES6">
+    <section id="ligas" class="section hud-separator" aria-labelledby="ligas-title">
+      <h2 id="ligas-title">LIGAS</h2>
+      <div class="league-grid">
+        <article class="league-card" role="button" tabindex="0" aria-haspopup="dialog" aria-controls="pes6-panel" data-target="pes6-panel">
+          <img src="assets/pes6.png" alt="PES 6 - Infinity Patch" />
+          <div class="league-card-content">
             <h3>PES 6 – Infinity Patch</h3>
-        </div>
+            <p>Competí en divisiones y escalá posiciones.</p>
+          </div>
+        </article>
 
-        <div class="card" data-target="sf-panel">
-            <img src="https://via.placeholder.com/400x200?text=Street+Fighter+II" alt="Street Fighter II">
+        <article class="league-card" role="button" tabindex="0" aria-haspopup="dialog" aria-controls="sf-panel" data-target="sf-panel">
+          <img src="assets/sfii.png" alt="Street Fighter II - Fightcade" />
+          <div class="league-card-content">
             <h3>Street Fighter II – Fightcade</h3>
-        </div>
+            <p>Liga 1 vs 1 con formato competitivo oficial.</p>
+          </div>
+        </article>
+      </div>
+    </section>
 
-    </div>
-</section>
-
-<!-- PES6 PANEL -->
-<div id="pes6-panel" class="panel hidden">
-    <button class="close-btn">&times;</button>
-    <img src="https://via.placeholder.com/800x200?text=PES+6+Infinity+Patch+Banner" alt="PES 6 Banner">
-    <h2>PES 6 – Infinity Patch</h2>
-
-    <h3>¿QUÉ ES?</h3>
-    <p>Liga online de PES 6 utilizando Infinity Patch.</p>
-
-    <h3>DIVISIONES</h3>
-    <p>- 4 divisiones</p>
-    <p>- 20 jugadores por división</p>
-
-    <h3>CÓMO SE JUEGA</h3>
-    <p>Los partidos se juegan cuando dos jugadores coinciden disponibles y coordinan por WhatsApp.</p>
-
-    <h3>QUÉ TENÉS QUE INSTALAR</h3>
-    <p>- PES 6</p>
-    <p>- Infinity Patch</p>
-
-    <h3>MENSAJE OFICIAL PARA NUEVOS JUGADORES</h3>
-    <div class="copy-box">
-        <textarea id="pes6-msg" readonly>
---------------------------------
-BIENVENIDO!
-EN ESTE MENSAJE TE DEJO TODO LO NECESARIO PARA EMPEZAR EN LA LIGA...
-https://youtu.be/IsKefVidC4A?si=RBQ4j3CIhWm2N2KJ
-...
---------------------------------
-        </textarea>
-        <button class="copy-btn" data-copy="pes6-msg">📋 Copiar mensaje</button>
-    </div>
-
-    <a href="#" class="btn primary" id="whatsapp-pes6">Ir al WhatsApp de PES 6</a>
-</div>
-
-<!-- Street Fighter Panel -->
-<div id="sf-panel" class="panel hidden">
-    <button class="close-btn">&times;</button>
-    <img src="https://via.placeholder.com/800x200?text=SF+II+Fightcade+Banner" alt="SFII Banner">
-    <h2>Street Fighter II – Fightcade</h2>
-
-    <h3>¿QUÉ ES?</h3>
-    <p>Liga 1 vs 1 de Street Fighter II jugada en Fightcade.</p>
-
-    <h3>DIVISIONES</h3>
-    <p>- Primera División (en inauguración)</p>
-
-    <h3>DÓNDE SE JUEGA</h3>
-    <p>Salón obligatorio de Fightcade: #STREET FIGHTER II – CHAMPION EDITION</p>
-
-    <h3>MENSAJE OFICIAL DE LA LIGA</h3>
-    <div class="copy-box">
-        <textarea id="sf-msg" readonly>
---------------------------------
-🔥 BIENVENIDO A LA LIGA DE STREET FIGHTER II – SUDAKA LEAGUE 🔥
-📹 VIDEO DE INSTALACIÓN (OBLIGATORIO)...
---------------------------------
-        </textarea>
-        <button class="copy-btn" data-copy="sf-msg">📋 Copiar mensaje</button>
-    </div>
-
-    <a href="#" class="btn primary" id="whatsapp-sf">Ir al WhatsApp de Street Fighter</a>
-</div>
-
-<section class="how-to-play">
-    <h2>¿CÓMO SE JUEGA?</h2>
-    <ul>
+    <section class="section panel-section hud-separator" aria-labelledby="como-juega-title">
+      <h2 id="como-juega-title">CÓMO SE JUEGA</h2>
+      <ul class="feature-list">
         <li>Sistema de divisiones</li>
         <li>Partidos coordinados por WhatsApp</li>
         <li>Resultados cuentan para tablas</li>
         <li>Respeto y juego limpio</li>
-    </ul>
-</section>
+      </ul>
+    </section>
 
-<section class="whatsapp-buttons">
-    <a href="#" class="btn big" id="whatsapp-pes6-2">Unirme a PES 6</a>
-    <a href="#" class="btn big" id="whatsapp-sf-2">Unirme a Street Fighter</a>
-</section>
+    <section class="section hud-separator" aria-labelledby="whatsapp-title">
+      <h2 id="whatsapp-title">WHATSAPP</h2>
+      <div class="whatsapp-grid">
+        <a id="wa-pes6" class="btn btn-primary btn-large" href="#" target="_blank" rel="noopener noreferrer">Unirme a PES 6</a>
+        <a id="wa-sf" class="btn btn-primary btn-large" href="#" target="_blank" rel="noopener noreferrer">Unirme a Street Fighter</a>
+      </div>
+    </section>
 
-<section class="faq">
-    <h2>FAQ</h2>
-    <details><summary>¿Hay horarios fijos?</summary><p>No, no hay horarios fijos.</p></details>
-    <details><summary>¿Cómo consigo rival?</summary><p>Coordinando por WhatsApp cuando estás disponible.</p></details>
-    <details><summary>¿Qué pasa si no juego una semana?</summary><p>Depende de tu división y reglas internas.</p></details>
-    <details><summary>¿Cómo se reportan resultados?</summary><p>En el grupo de WhatsApp correspondiente.</p></details>
-    <details><summary>¿Necesito joystick?</summary><p>No es obligatorio, pero recomendado.</p></details>
-    <details><summary>¿Dónde pido ayuda?</summary><p>En el grupo de WhatsApp oficial.</p></details>
-</section>
+    <section class="section faq" aria-labelledby="faq-title">
+      <h2 id="faq-title">FAQ</h2>
+      <details>
+        <summary>¿Hay horarios fijos?</summary>
+        <p>No. Se juega cuando coinciden dos jugadores disponibles.</p>
+      </details>
+      <details>
+        <summary>¿Cómo consigo rival?</summary>
+        <p>Entrás al grupo de WhatsApp de tu liga y avisás que estás disponible.</p>
+      </details>
+      <details>
+        <summary>¿Qué pasa si no juego una semana?</summary>
+        <p>Puede impactar en tu posición. Recomendamos avisar en tu grupo y mantener actividad.</p>
+      </details>
+      <details>
+        <summary>¿Cómo se reportan resultados?</summary>
+        <p>En el grupo correspondiente de WhatsApp, según el formato de cada liga.</p>
+      </details>
+      <details>
+        <summary>¿Necesito joystick?</summary>
+        <p>No es obligatorio, pero sí muy recomendado para una mejor experiencia competitiva.</p>
+      </details>
+      <details>
+        <summary>¿Dónde pido ayuda?</summary>
+        <p>En la comunidad de WhatsApp o en tu grupo de liga.</p>
+      </details>
+    </section>
+  </main>
 
-<button id="back-to-top">Volver arriba ⬆️</button>
+  <div id="modal-overlay" class="modal-overlay" hidden>
+    <section id="pes6-panel" class="league-modal" role="dialog" aria-modal="true" aria-labelledby="pes6-modal-title" hidden>
+      <button class="close-btn" type="button" aria-label="Cerrar panel">×</button>
+      <img class="modal-banner" src="assets/pes6.png" alt="PES 6 Banner" />
+      <h2 id="pes6-modal-title">PES 6 – INFINITY PATCH</h2>
 
-<script src="app.js"></script>
+      <h3>¿QUÉ ES?</h3>
+      <p>Liga online de PES 6 utilizando Infinity Patch.</p>
 
+      <h3>DIVISIONES</h3>
+      <ul>
+        <li>4 divisiones</li>
+        <li>20 jugadores por división</li>
+      </ul>
+
+      <h3>CÓMO SE JUEGA</h3>
+      <p>Los partidos se juegan cuando dos jugadores coinciden disponibles y coordinan por WhatsApp.</p>
+
+      <h3>QUÉ TENÉS QUE INSTALAR</h3>
+      <ul>
+        <li>PES 6</li>
+        <li>Infinity Patch</li>
+      </ul>
+
+      <h3>MENSAJE OFICIAL PARA NUEVOS JUGADORES</h3>
+      <div class="copy-box">
+        <textarea id="pes6-message" readonly>BIENVENIDO!
+
+EN ESTE MENSAJE TE DEJO TODO LO NECESARIO PARA EMPEZAR EN LA LIGA SOLO NECESITAS ESTAS DOS COSAS:
+
+INFINITTY PATCH, ESTE ES EL PARCHE QUE USAMOS: https://youtu.be/IsKefVidC4A?si=RBQ4j3CIhWm2N2KJ
+
+RECORDÁ QUE LA INSTALACIÓN DE LOS ESTADIOS ES OPCIONAL Y NO OBLIGATORIA
+
+Y ACA TE DEJO UNA BREVE EXPLICACIÓN DEL ARCHIVO HOST:
+
+van a la pagina: https://pes6comunidad.trixnodes.com
+en "registro" se crean la cuenta del server
+
+Una vez que están registrados, el último paso sería descargar el selector de host: https://www.mediafire.com/file/cue87dwh4rt8phs/PES6HostSelector.zip/file
+
+Una vez instalado lo ejecutan como administrador seleccionan pes6comunidad y apretan en salir
+
+UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES6</textarea>
+        <button class="btn btn-secondary copy-btn" type="button" data-copy-target="pes6-message">📋 Copiar mensaje</button>
+      </div>
+
+      <a id="wa-pes6-modal" class="btn btn-primary" href="#" target="_blank" rel="noopener noreferrer">Ir al WhatsApp de PES 6</a>
+    </section>
+
+    <section id="sf-panel" class="league-modal" role="dialog" aria-modal="true" aria-labelledby="sf-modal-title" hidden>
+      <button class="close-btn" type="button" aria-label="Cerrar panel">×</button>
+      <img class="modal-banner" src="assets/sfii.png" alt="Street Fighter II Banner" />
+      <h2 id="sf-modal-title">STREET FIGHTER II – FIGHTCADE</h2>
+
+      <h3>¿QUÉ ES?</h3>
+      <p>Liga 1 vs 1 de Street Fighter II jugada en Fightcade.</p>
+
+      <h3>DIVISIONES</h3>
+      <ul>
+        <li>Primera División (en inauguración)</li>
+      </ul>
+
+      <h3>DÓNDE SE JUEGA</h3>
+      <p>Salón obligatorio de Fightcade: #STREET FIGHTER II – CHAMPION EDITION</p>
+
+      <h3>MENSAJE OFICIAL DE LA LIGA</h3>
+      <div class="copy-box">
+        <textarea id="sf-message" readonly>🔥 BIENVENIDO A LA LIGA DE STREET FIGHTER II – SUDAKA LEAGUE 🔥
+
+📹 VIDEO DE INSTALACIÓN (OBLIGATORIO)
+Este video explica únicamente cómo instalar y configurar Fightcade y el juego: https://www.youtube.com/watch?v=tM5yVYoY-7w&t=126s
+
+⚠️ IMPORTANTE: El video NO explica el funcionamiento de la liga.
+
+🎮 ¿CÓMO FUNCIONA LA LIGA?
+La liga se juega en Fightcade con Street Fighter II.
+
+📍 SALÓN DE FIGHTCADE (OBLIGATORIO)
+#STREET FIGHTER II – CHAMPION EDITION
+
+🔍 ¿CÓMO BUSCAR PARTIDA?
+1) Entrar a Fightcade
+2) Buscar el salón indicado
+3) Avisar en el grupo de WhatsApp que estás disponible
+4) Coordinar, invitar y jugar
+5) Enviar resultado al grupo
+
+⏱️ DATOS CLAVE
+- No hay horarios fijos
+- No hay lobby automático
+- Los partidos se juegan cuando coinciden dos jugadores
+
+🏆 OBJETIVO
+Competir, sumar puntos y escalar posiciones.
+
+🔥 Bienvenido a Sudaka League – Street Fighter II 🔥</textarea>
+        <button class="btn btn-secondary copy-btn" type="button" data-copy-target="sf-message">📋 Copiar mensaje</button>
+      </div>
+
+      <a id="wa-sf-modal" class="btn btn-primary" href="#" target="_blank" rel="noopener noreferrer">Ir al WhatsApp de Street Fighter</a>
+    </section>
+  </div>
+
+  <button id="back-to-top" class="btn btn-primary back-to-top" type="button" aria-label="Volver arriba">Volver arriba ↑</button>
+
+  <script src="app.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,149 +1,336 @@
+:root {
+  --bg-main: #030814;
+  --bg-panel: rgba(10, 22, 46, 0.82);
+  --bg-elevated: #0c1b39;
+  --text-main: #e8f1ff;
+  --text-soft: #b8c6ea;
+  --line: rgba(84, 164, 255, 0.5);
+  --line-strong: rgba(99, 184, 255, 0.9);
+  --glow: 0 0 0.7rem rgba(89, 173, 255, 0.45);
+}
+
 * {
-    box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
 }
 
 body {
-    margin: 0;
-    font-family: Arial, Helvetica, sans-serif;
-    background: #f5f7fa;
-    color: #0a1f44;
+  margin: 0;
+  font-family: "Inter", system-ui, sans-serif;
+  color: var(--text-main);
+  background: radial-gradient(circle at 20% 0%, #13254d 0%, #050a17 40%, #03060f 100%);
+  min-height: 100vh;
+  overflow-x: hidden;
 }
 
-/* HERO */
+body.no-scroll {
+  overflow: hidden;
+}
+
+.bg-effects {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: -1;
+  background-image:
+    radial-gradient(circle at 20% 30%, rgba(99, 179, 255, 0.15) 0 2px, transparent 2px),
+    radial-gradient(circle at 75% 20%, rgba(99, 179, 255, 0.18) 0 1px, transparent 1px),
+    repeating-linear-gradient(90deg, transparent 0 32px, rgba(59, 104, 163, 0.1) 33px),
+    linear-gradient(to bottom, rgba(75, 130, 210, 0.07), transparent 24%);
+  opacity: 0.85;
+}
+
+.section {
+  width: min(1100px, 92%);
+  margin: 0 auto;
+  padding: 2.8rem 0;
+}
+
+h1,
+h2,
+h3,
+.hero-kicker {
+  font-family: "Orbitron", "Inter", sans-serif;
+  letter-spacing: 0.04em;
+}
+
+h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(1.4rem, 4vw, 2rem);
+  text-shadow: var(--glow);
+}
+
 .hero {
-    background: linear-gradient(135deg, #0a1f44, #0d47a1);
-    color: white;
-    padding: 60px 20px;
-    text-align: center;
+  text-align: center;
+  padding-top: 4.2rem;
+}
+
+.hero-kicker {
+  margin: 0;
+  font-size: 0.78rem;
+  color: #90bbff;
+  text-transform: uppercase;
 }
 
 .hero h1 {
-    font-size: 48px;
-    margin-bottom: 10px;
+  margin: 0.8rem 0 0.5rem;
+  font-size: clamp(2.2rem, 13vw, 5.8rem);
+  line-height: 1;
+  text-shadow: 0 0 1rem rgba(70, 148, 255, 0.65);
 }
 
-.hero h2 {
-    font-size: 20px;
-    font-weight: normal;
-    opacity: 0.9;
+.subtitle,
+.hero-copy {
+  margin: 0 auto;
+  max-width: 740px;
+  color: var(--text-soft);
 }
 
-.hero p {
-    max-width: 600px;
-    margin: 20px auto;
+.subtitle {
+  font-weight: 700;
+  margin-bottom: 0.8rem;
 }
 
-/* BOTONES */
+.hero-actions {
+  display: flex;
+  gap: 0.8rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 1.4rem;
+}
+
 .btn {
-    padding: 12px 22px;
-    border-radius: 6px;
-    text-decoration: none;
-    font-weight: bold;
-    display: inline-block;
-    cursor: pointer;
+  border: 1px solid var(--line);
+  color: #ddedff;
+  text-decoration: none;
+  background: rgba(27, 58, 107, 0.28);
+  padding: 0.72rem 1.05rem;
+  border-radius: 0.7rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 220ms ease, border-color 220ms ease;
 }
 
-.primary {
-    background: #2196f3;
-    color: white;
+.btn:hover,
+.btn:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--line-strong);
+  box-shadow: var(--glow), 0 0 1.2rem rgba(90, 170, 255, 0.3);
 }
 
-.secondary {
-    background: white;
-    color: #0d47a1;
+.btn:focus-visible,
+.league-card:focus-visible,
+summary:focus-visible,
+.close-btn:focus-visible {
+  outline: 2px solid #8ec5ff;
+  outline-offset: 2px;
 }
 
-/* SECCIONES */
-.section {
-    padding: 50px 20px;
-    max-width: 1000px;
-    margin: auto;
+.btn-primary {
+  background: linear-gradient(180deg, rgba(58, 121, 218, 0.4), rgba(14, 36, 74, 0.75));
 }
 
-.section h2 {
-    text-align: center;
-    margin-bottom: 20px;
+.btn-secondary {
+  background: rgba(6, 18, 38, 0.72);
 }
 
-/* LIGAS */
-.ligas-grid {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 20px;
+.panel-section,
+.faq,
+.league-card,
+.league-modal {
+  background: var(--bg-panel);
+  border: 1px solid rgba(92, 163, 250, 0.35);
+  border-radius: 1rem;
+  box-shadow: inset 0 0 0 1px rgba(52, 93, 155, 0.2), 0 12px 40px rgba(3, 8, 19, 0.55);
+  backdrop-filter: blur(4px);
 }
 
-.liga-card {
-    background: white;
-    border-radius: 10px;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-    overflow: hidden;
-    cursor: pointer;
-    transition: transform 0.2s;
+.hud-separator {
+  position: relative;
 }
 
-.liga-card:hover {
-    transform: scale(1.03);
+.hud-separator::after {
+  content: "";
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  bottom: -0.35rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(99, 184, 255, 0.9), transparent);
 }
 
-.liga-img {
-    height: 160px;
+.panel-section,
+.faq {
+  padding: 1.4rem;
 }
 
-.liga-img.pes {
-    background: linear-gradient(45deg, #1565c0, #42a5f5);
+.league-grid {
+  display: grid;
+  gap: 1rem;
 }
 
-.liga-img.sf {
-    background: linear-gradient(45deg, #b71c1c, #e53935);
+.league-card {
+  overflow: hidden;
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 220ms ease;
 }
 
-.liga-card h3 {
-    padding: 15px;
-    text-align: center;
+.league-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 0 1.5rem rgba(99, 184, 255, 0.25);
 }
 
-/* PANEL */
-.panel {
-    position: fixed;
-    top: 5%;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 90%;
-    max-width: 800px;
-    background: white;
-    padding: 30px;
-    border-radius: 12px;
-    box-shadow: 0 10px 40px rgba(0,0,0,0.4);
-    overflow-y: auto;
-    max-height: 90vh;
-    z-index: 100;
+.league-card img,
+.modal-banner {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+  display: block;
 }
 
-.hidden {
-    display: none;
+.league-card-content {
+  padding: 1rem;
 }
 
-.close {
-    position: absolute;
-    top: 10px;
-    right: 15px;
-    border: none;
-    background: none;
-    font-size: 20px;
-    cursor: pointer;
+.feature-list {
+  padding-left: 1.2rem;
+  margin: 0;
 }
 
-/* COPY */
+.feature-list li {
+  margin-bottom: 0.45rem;
+}
+
+.whatsapp-grid {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.btn-large {
+  text-align: center;
+  padding: 1rem;
+  font-size: 1rem;
+}
+
+.faq details {
+  border: 1px solid rgba(90, 151, 228, 0.3);
+  border-radius: 0.75rem;
+  padding: 0.8rem;
+  background: rgba(8, 24, 51, 0.6);
+  margin-bottom: 0.6rem;
+}
+
+.faq summary {
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.faq p {
+  color: var(--text-soft);
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 8, 20, 0.78);
+  z-index: 20;
+  padding: 1rem;
+  display: grid;
+  place-items: center;
+}
+
+.league-modal {
+  width: min(900px, 95vw);
+  max-height: 92vh;
+  overflow-y: auto;
+  padding: 1.1rem;
+  position: relative;
+  animation: modal-in 220ms ease;
+}
+
+@keyframes modal-in {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.close-btn {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  border: 1px solid var(--line);
+  color: #e5f3ff;
+  background: rgba(4, 13, 28, 0.9);
+  font-size: 1.5rem;
+  line-height: 1;
+  border-radius: 0.4rem;
+  width: 2rem;
+  height: 2rem;
+  cursor: pointer;
+}
+
 .copy-box textarea {
-    width: 100%;
-    height: 180px;
-    margin: 10px 0;
+  width: 100%;
+  min-height: 230px;
+  resize: vertical;
+  padding: 0.8rem;
+  color: #dfeeff;
+  font-family: "Inter", sans-serif;
+  border-radius: 0.8rem;
+  border: 1px solid rgba(113, 182, 255, 0.35);
+  background: rgba(5, 19, 39, 0.8);
 }
 
-/* TOP */
-#top {
-    position: fixed;
-    bottom: 20px;
-    right: 20px;
-    padding: 10px;
+.copy-btn {
+  margin-top: 0.65rem;
+}
+
+.back-to-top {
+  position: fixed;
+  right: 0.9rem;
+  bottom: 1rem;
+  z-index: 10;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.back-to-top.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (min-width: 760px) {
+  .section {
+    padding: 3.2rem 0;
+  }
+
+  .league-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .whatsapp-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .league-card img,
+  .modal-banner {
+    height: 260px;
+  }
+
+  .league-modal {
+    padding: 1.6rem;
+  }
+}
+
+.modal-overlay[hidden],
+.league-modal[hidden] {
+  display: none !important;
 }


### PR DESCRIPTION
### Motivation
- Entregar el front-end completo de "Sudaka League" con estética gaming/esports oscura y elementos HUD, siguiendo las reglas visuales y la estructura de contenido obligatoria.
- Proveer una solución sin dependencias (solo `index.html`, `styles.css`, `app.js`) que sea mobile-first, accesible y lista para GitHub Pages.

### Description
- Rebuilt toda la estructura en `index.html` con hero, secciones (`¿Qué es?`, `Ligas`, `Cómo se juega`, `WhatsApp`, `FAQ`), dos tarjetas de ligas y dos paneles/modales con el contenido obligatorio y los mensajes oficiales exactos en cajas copiables.
- Implementé la estética en `styles.css` con paleta oscuro/azul eléctrico, glow suave, textura tipo estrellas/grid, tipografías `Orbitron` + `Inter`, separadores HUD, tarjetas con `object-fit: cover` y animaciones/transiciones suaves; responsive mobile-first y layout de 2 columnas en pantallas grandes.
- Implementé la lógica en `app.js` con constantes editables `WHATSAPP_PES6`, `WHATSAPP_SF`, `WHATSAPP_COMUNIDAD`, asignación centralizada de links, apertura/cierre de modales (click, fuera, `Escape`, botón cerrar), bloqueo de scroll del `body`, focus trap y manejo de foco, botón funcional `Volver arriba`, y botón `📋 Copiar mensaje` usando Clipboard API con fallback por textarea.
- Añadí regla CSS para ocultar correctamente elementos con `hidden` (`.modal-overlay[hidden], .league-modal[hidden] { display: none !important; }`) para evitar intercepciones de eventos cuando los modales están cerrados.

### Testing
- Ejecuté la verificación de sintaxis JS con `node --check app.js` y completó correctamente.;
- Serví el sitio con `python3 -m http.server 4173` y validé visualmente las páginas; se capturaron capturas con Playwright para la home y el modal PES6 (artifacts generados);
- Se observaron `404` en las peticiones a `assets/pes6.png` y `assets/sfii.png` durante la prueba porque esos archivos no estaban presentes en el entorno, pero las rutas en el código apuntan correctamente a `assets/pes6.png` y `assets/sfii.png` según los requisitos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863bb3e5b48332a5b136740810979d)