### PR TITLE
Adjust panel typography and spacing for safer title wrapping

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -54,13 +54,16 @@ h2,
 h3,
 .hero-kicker {
   font-family: "Orbitron", "Inter", sans-serif;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.03em;
 }
 
 h2 {
   margin: 0 0 1rem;
-  font-size: clamp(1.4rem, 4vw, 2rem);
+  font-size: clamp(1.25rem, 3.6vw, 1.85rem);
+  line-height: 1.18;
   text-shadow: var(--glow);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .hero {
@@ -164,7 +167,24 @@ summary:focus-visible,
 
 .panel-section,
 .faq {
-  padding: 1.4rem;
+  padding: clamp(1.5rem, 4vw, 2rem);
+}
+
+.panel-section h2,
+.faq h2,
+.league-modal h2,
+.league-card-content h3,
+.league-modal h3 {
+  letter-spacing: 0.02em;
+  line-height: 1.18;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  hyphens: auto;
+}
+
+.league-card-content h3,
+.league-modal h3 {
+  font-size: clamp(1rem, 2.8vw, 1.28rem);
 }
 
 .league-grid {
@@ -192,7 +212,7 @@ summary:focus-visible,
 }
 
 .league-card-content {
-  padding: 1rem;
+  padding: clamp(1.1rem, 3vw, 1.35rem);
 }
 
 .feature-list {
@@ -218,7 +238,7 @@ summary:focus-visible,
 .faq details {
   border: 1px solid rgba(90, 151, 228, 0.3);
   border-radius: 0.75rem;
-  padding: 0.8rem;
+  padding: clamp(0.95rem, 2.5vw, 1.15rem);
   background: rgba(8, 24, 51, 0.6);
   margin-bottom: 0.6rem;
 }
@@ -246,7 +266,7 @@ summary:focus-visible,
   width: min(900px, 95vw);
   max-height: 92vh;
   overflow-y: auto;
-  padding: 1.1rem;
+  padding: clamp(1.25rem, 3.5vw, 1.8rem);
   position: relative;
   animation: modal-in 220ms ease;
 }


### PR DESCRIPTION
### Motivation
- Headings set in Orbitron were too wide/large and risked touching or overflowing panel borders on some viewports, so safer wrapping and breathing room was needed. 
- Preserve the gaming/esports visual (glow, weight) while improving readability and preventing clipping inside boxed UI elements. 
- Apply fixes only in `styles.css` as requested, without changing HTML or JS.

### Description
- Reduced global heading density by lowering Orbitron `letter-spacing` and tightened `h2` sizing to `font-size: clamp(1.25rem, 3.6vw, 1.85rem)` with `line-height: 1.18` for more reliable layout. 
- Added safe wrapping rules (`overflow-wrap: anywhere`, `word-break: break-word`, `hyphens: auto`) and a slightly reduced `letter-spacing` for panel/modal/card headings to avoid horizontal overflow. 
- Increased internal spacing using responsive `padding: clamp(...)` on `.panel-section`, `.faq`, `.league-modal`, `.league-card-content` and `.faq details` so titles no longer touch container edges. 
- Kept existing glow, shadows and overall esports styling intact while making typography more breathable.

### Testing
- Started a local server with `python3 -m http.server 4173 --bind 0.0.0.0` and confirmed `styles.css` was served successfully. 
- Ran a Playwright script that captured desktop and mobile screenshots (`artifacts/sudaka-desktop.png`, `artifacts/sudaka-mobile.png`) which completed successfully and show improved spacing. 
- Reviewed the updated `styles.css` to ensure only typography and padding changes were introduced and no HTML/JS behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986418eca7083329858ab9f1128eb50)