### PR TITLE
Ajusta tamaños y espaciado de títulos y paneles en styles.css (raíz)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -54,13 +54,13 @@ h2,
 h3,
 .hero-kicker {
   font-family: "Orbitron", "Inter", sans-serif;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.018em;
 }
 
 h2 {
   margin: 0 0 1rem;
-  font-size: clamp(1.25rem, 3.6vw, 1.85rem);
-  line-height: 1.18;
+  font-size: clamp(1.15rem, 3.15vw, 1.68rem);
+  line-height: 1.14;
   text-shadow: var(--glow);
   overflow-wrap: anywhere;
   word-break: break-word;
@@ -167,7 +167,7 @@ summary:focus-visible,
 
 .panel-section,
 .faq {
-  padding: clamp(1.5rem, 4vw, 2rem);
+  padding: clamp(1.75rem, 4.8vw, 2.35rem);
 }
 
 .panel-section h2,
@@ -175,16 +175,22 @@ summary:focus-visible,
 .league-modal h2,
 .league-card-content h3,
 .league-modal h3 {
-  letter-spacing: 0.02em;
-  line-height: 1.18;
+  letter-spacing: 0.012em;
+  line-height: 1.14;
   overflow-wrap: anywhere;
   word-break: break-word;
   hyphens: auto;
 }
 
+.panel-section h2,
+.faq h2,
+.league-modal h2 {
+  font-size: clamp(1.08rem, 2.85vw, 1.48rem);
+}
+
 .league-card-content h3,
 .league-modal h3 {
-  font-size: clamp(1rem, 2.8vw, 1.28rem);
+  font-size: clamp(0.95rem, 2.35vw, 1.15rem);
 }
 
 .league-grid {
@@ -212,7 +218,7 @@ summary:focus-visible,
 }
 
 .league-card-content {
-  padding: clamp(1.1rem, 3vw, 1.35rem);
+  padding: clamp(1.3rem, 3.6vw, 1.65rem);
 }
 
 .feature-list {
@@ -266,7 +272,7 @@ summary:focus-visible,
   width: min(900px, 95vw);
   max-height: 92vh;
   overflow-y: auto;
-  padding: clamp(1.25rem, 3.5vw, 1.8rem);
+  padding: clamp(1.5rem, 4.1vw, 2.05rem);
   position: relative;
   animation: modal-in 220ms ease;
 }
@@ -346,7 +352,7 @@ summary:focus-visible,
   }
 
   .league-modal {
-    padding: 1.6rem;
+    padding: 1.85rem;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Reducir el tamaño y el espaciado de títulos Orbitron que están rozando los bordes de los paneles para mejorar la legibilidad en desktop y mobile. 
- Aumentar el espacio interior de paneles/tarjetas/modales para que el diseño respire sin romper la estética gaming/esports. 
- Mantener efectos visuales (glow, paleta de colores) y evitar cambios en HTML/JS.

### Description
- Se redujo el `letter-spacing` global de títulos Orbitron pasando de `0.03em` a `0.018em` para evitar trazos excesivos. 
- Se ajustó `h2` a `font-size: clamp(1.15rem, 3.15vw, 1.68rem)` y `line-height: 1.14` para un tamaño más contenido con `clamp()` (mobile-first). 
- Se agregó un `font-size` con `clamp()` específico para encabezados dentro de paneles (`.panel-section h2`, `.faq h2`, `.league-modal h2`) y se redujo `letter-spacing` y `line-height` en esos encabezados para mejor ajuste. 
- Se aumentó el `padding` interno de `.panel-section`, `.faq`, `.league-card-content` y `.league-modal` mediante valores `clamp()` y se incrementó la `padding` en la media query de escritorio para más aire en contenedores. 
- Se mantuvieron y reforzaron `overflow-wrap: anywhere`, `word-break: break-word` y `hyphens: auto` en títulos para permitir wraps seguros; no se tocaron glow ni colores. 
- ÚNICO archivo modificado: `styles.css` en la raíz del repositorio.

### Testing
- Ejecuté `git status --short` y `git diff -- styles.css` para revisar los cambios y confirmar que solo se tocó `styles.css` (OK). 
- Se creó un commit con los cambios y el mensaje correspondiente (OK). 
- Levanté un servidor local con `python3 -m http.server 4173` y generé una captura de la página con Playwright (`artifacts/homepage-updated-styles.png`) para validar la renderización de estilos; la CSS cargó correctamente y la captura se generó (OK). 
- Durante la validación el servidor devolvió 404 para algunos assets de imagen (`/assets/pes6.png`, `/assets/sfii.png`), lo que es una limitación de este entorno y no afecta la comprobación de la hoja de estilos (WARN).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69864496d8508332bb5014667bb536c2)