### PR TITLE
Mejora espaciado de paneles y unifica CTA de WhatsApp

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,3 @@
-const WHATSAPP_PES6 = "https://...";
-const WHATSAPP_SF = "https://...";
 const WHATSAPP_COMUNIDAD = "https://...";
 
 const overlay = document.getElementById("modal-overlay");
@@ -16,10 +14,8 @@ let lastFocusedElement = null;
 function applyWhatsAppLinks() {
   const links = {
     "cta-comunidad": WHATSAPP_COMUNIDAD,
-    "wa-pes6": WHATSAPP_PES6,
-    "wa-pes6-modal": WHATSAPP_PES6,
-    "wa-sf": WHATSAPP_SF,
-    "wa-sf-modal": WHATSAPP_SF
+    "wa-pes6-modal": WHATSAPP_COMUNIDAD,
+    "wa-sf-modal": WHATSAPP_COMUNIDAD
   };
 
   Object.entries(links).forEach(([id, value]) => {

--- a/index.html
+++ b/index.html
@@ -71,14 +71,6 @@
       </ul>
     </section>
 
-    <section class="section hud-separator" aria-labelledby="whatsapp-title">
-      <h2 id="whatsapp-title">WHATSAPP</h2>
-      <div class="whatsapp-grid">
-        <a id="wa-pes6" class="btn btn-primary btn-large" href="#" target="_blank" rel="noopener noreferrer">Unirme a PES 6</a>
-        <a id="wa-sf" class="btn btn-primary btn-large" href="#" target="_blank" rel="noopener noreferrer">Unirme a Street Fighter</a>
-      </div>
-    </section>
-
     <section class="section faq" aria-labelledby="faq-title">
       <h2 id="faq-title">FAQ</h2>
       <details>
@@ -155,7 +147,7 @@ UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES
         <button class="btn btn-secondary copy-btn" type="button" data-copy-target="pes6-message">📋 Copiar mensaje</button>
       </div>
 
-      <a id="wa-pes6-modal" class="btn btn-primary" href="#" target="_blank" rel="noopener noreferrer">Ir al WhatsApp de PES 6</a>
+      <a id="wa-pes6-modal" class="btn btn-primary" href="#" target="_blank" rel="noopener noreferrer">Ir a la comunidad</a>
     </section>
 
     <section id="sf-panel" class="league-modal" role="dialog" aria-modal="true" aria-labelledby="sf-modal-title" hidden>
@@ -208,7 +200,7 @@ Competir, sumar puntos y escalar posiciones.
         <button class="btn btn-secondary copy-btn" type="button" data-copy-target="sf-message">📋 Copiar mensaje</button>
       </div>
 
-      <a id="wa-sf-modal" class="btn btn-primary" href="#" target="_blank" rel="noopener noreferrer">Ir al WhatsApp de Street Fighter</a>
+      <a id="wa-sf-modal" class="btn btn-primary" href="#" target="_blank" rel="noopener noreferrer">Ir a la comunidad</a>
     </section>
   </div>
 

--- a/styles.css
+++ b/styles.css
@@ -167,7 +167,7 @@ summary:focus-visible,
 
 .panel-section,
 .faq {
-  padding: clamp(1.75rem, 4.8vw, 2.35rem);
+  padding: clamp(2.25rem, 5.6vw, 3.1rem);
 }
 
 .panel-section h2,
@@ -191,6 +191,19 @@ summary:focus-visible,
 .league-card-content h3,
 .league-modal h3 {
   font-size: clamp(0.95rem, 2.35vw, 1.15rem);
+}
+
+
+.panel-section h2 {
+  margin-bottom: 1.2rem;
+  padding-inline: clamp(0.3rem, 1.2vw, 0.55rem);
+}
+
+.panel-section p,
+.panel-section li {
+  line-height: 1.62;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .league-grid {
@@ -333,9 +346,27 @@ summary:focus-visible,
   pointer-events: auto;
 }
 
+
+@media (max-width: 759px) {
+  .panel-section,
+  .faq {
+    padding: clamp(2.25rem, 8vw, 2.85rem);
+  }
+
+  .panel-section h2 {
+    margin-bottom: 1.05rem;
+    padding-inline: 0.45rem;
+  }
+}
+
 @media (min-width: 760px) {
   .section {
     padding: 3.2rem 0;
+  }
+
+  .panel-section,
+  .faq {
+    padding: clamp(2.5rem, 4vw, 3.1rem);
   }
 
   .league-grid {


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad y la respiración del contenido dentro de los paneles (especialmente el bloque “¿QUÉ ES SUDAKA LEAGUE?”) y ofrecer un único acceso claro a la comunidad de WhatsApp en lugar de botones por liga.

### Description
- Aumenté el padding de `.panel-section` y `.faq` y añadí reglas específicas para mobile/desktop para dar más espacio interno; también añadí `padding-inline` para títulos largos en `styles.css`.
- Incrementé `line-height` para párrafos y listas dentro de paneles y reforcé el wrapping con `overflow-wrap: anywhere` y `word-break: break-word` en `styles.css`.
- Eliminé la sección de botones por liga en `index.html` y reetiqueté los botones dentro de los modales a `Ir a la comunidad` para mantener un único CTA visible en el hero.
- Simplifiqué `app.js` eliminando las constantes por liga y dejando solo `WHATSAPP_COMUNIDAD`, además de remapear los enlaces de los botones restantes para que apunten al mismo enlace.

### Testing
- Ejecuté `node --check app.js` y no se reportaron errores (pasó).
- Monté un servidor local con `python -m http.server` y validé visualmente mediante un script Playwright que generó capturas de pantalla en desktop y mobile (navegación y render OK).
- Verifiqué con búsquedas (`rg`) que las referencias a los botones/constantes por liga fueron removidas o reemplazadas y que los IDs relevantes apuntan a `WHATSAPP_COMUNIDAD` (pasó).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986465fcb348332b2bb3361dccdc9cb)