### PR TITLE
Mostrar banners de ligas en cards (SFII/PES6)

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
       <h2 id="ligas-title">LIGAS</h2>
       <div class="league-grid">
         <article class="league-card" role="button" tabindex="0" aria-haspopup="dialog" aria-controls="pes6-panel" data-target="pes6-panel">
-          <img src="assets/pes6.png" alt="PES 6 - Infinity Patch" />
+          <img class="league-card-banner" src="assets/pes6.jpg" alt="PES 6 - Infinity Patch" />
           <div class="league-card-content">
             <h3>PES 6 – Infinity Patch</h3>
             <p>Competí en divisiones y escalá posiciones.</p>
@@ -59,7 +59,7 @@
         </article>
 
         <article class="league-card" role="button" tabindex="0" aria-haspopup="dialog" aria-controls="sf-panel" data-target="sf-panel">
-          <img src="assets/sfii.png" alt="Street Fighter II - Fightcade" />
+          <img class="league-card-banner" src="assets/sfii.jpg" alt="Street Fighter II - Fightcade" />
           <div class="league-card-content">
             <h3>Street Fighter II – Fightcade</h3>
             <p>Liga 1 vs 1 con formato competitivo oficial.</p>

--- a/styles.css
+++ b/styles.css
@@ -222,12 +222,17 @@ summary:focus-visible,
   box-shadow: 0 0 1.5rem rgba(99, 184, 255, 0.25);
 }
 
-.league-card img,
+.league-card-banner,
 .modal-banner {
   width: 100%;
   height: 220px;
   object-fit: cover;
   display: block;
+}
+
+.league-card-banner {
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
 }
 
 .league-card-content {


### PR DESCRIPTION
### Motivation
- Mostrar los banners de las ligas dentro de cada card para que las imágenes sean visibles en la sección `LIGAS`.
- Preparar el path de `PES6` con la imagen `assets/pes6.jpg` aunque el asset aún no esté subido.

### Description
- En `index.html` se reemplazaron las etiquetas `<img>` de las cards de liga para usar `class="league-card-banner"` y los paths `assets/pes6.jpg` y `assets/sfii.jpg` sin tocar textos ni la estructura clickeable de los `article` (roles, `tabindex`, `data-target`).
- En `styles.css` se consolidó el estilo de banners (`width: 100%`, `height: 220px`, `object-fit: cover`) reutilizando la regla para `modal-banner` y se añadió `border-top-left/right-radius: 1rem` en `.league-card-banner` para bordes superiores redondeados.
- No se modificaron textos, comportamiento de modales ni accesibilidad de las cards.

### Testing
- Inspección de archivos y líneas con `nl`/`sed` para verificar los cambios en `index.html` y `styles.css`, confirmando que solo esas dos files fueron modificadas (OK).
- Levanté un servidor local con `python3 -m http.server 4173` para habilitar pruebas visuales en `http://127.0.0.1:4173` (servidor iniciado correctamente).
- Intentos de captura visual automatizada con Playwright en Chromium y Firefox fallaron por limitaciones del entorno (Chromium dio `SIGSEGV` y Firefox devolvió `NS_ERROR_NET_RESET`).
- No hay tests unitarios adicionales; los cambios son de presentación y fueron verificados por revisión de diff y contenido.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69866fe2f6cc8332b9bba451090a1005)