### PR TITLE
Agregar pestañas por liga en modales con contenido actualizado de PES6 y SFII

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 const WHATSAPP_COMUNIDAD = "https://chat.whatsapp.com/DvRyA2bxAC67x0ulPQYvCa?mode=gi_t";
 
-
 const overlay = document.getElementById("modal-overlay");
 const modals = [...document.querySelectorAll(".league-modal")];
 const triggers = [...document.querySelectorAll(".league-card")];
@@ -27,7 +26,7 @@ function applyWhatsAppLinks() {
 
 function getFocusableElements(container) {
   return [...container.querySelectorAll('button, [href], textarea, details, summary, [tabindex]:not([tabindex="-1"])')]
-    .filter((element) => !element.hasAttribute("disabled"));
+    .filter((element) => !element.hasAttribute("disabled") && !element.hidden);
 }
 
 function trapFocus(event) {
@@ -51,6 +50,40 @@ function trapFocus(event) {
   }
 }
 
+function activateTab(modal, tabButton) {
+  const tabButtons = [...modal.querySelectorAll(".tab-btn")];
+  const tabPanels = [...modal.querySelectorAll(".tab-panel")];
+  const targetPanelId = tabButton.dataset.tab;
+
+  tabButtons.forEach((button) => {
+    const isActive = button === tabButton;
+    button.classList.toggle("is-active", isActive);
+    button.setAttribute("aria-selected", String(isActive));
+  });
+
+  tabPanels.forEach((panel) => {
+    const isActive = panel.id === targetPanelId;
+    panel.hidden = !isActive;
+    panel.classList.toggle("is-active", isActive);
+  });
+}
+
+function setupTabs() {
+  modals.forEach((modal) => {
+    const tabButtons = [...modal.querySelectorAll(".tab-btn")];
+    if (!tabButtons.length) return;
+
+    tabButtons.forEach((button) => {
+      button.addEventListener("click", () => activateTab(modal, button));
+    });
+  });
+}
+
+function resetModalToDefaultTab(modal) {
+  const defaultTabButton = modal.querySelector(".tab-btn");
+  if (defaultTabButton) activateTab(modal, defaultTabButton);
+}
+
 function openModal(modalId) {
   const modal = document.getElementById(modalId);
   if (!modal) return;
@@ -61,6 +94,8 @@ function openModal(modalId) {
   activeModal = modal;
   document.body.classList.add("no-scroll");
   lastFocusedElement = document.activeElement;
+
+  resetModalToDefaultTab(modal);
 
   const initialFocusable = getFocusableElements(modal)[0];
   if (initialFocusable) initialFocusable.focus();
@@ -151,4 +186,5 @@ backToTopButton.addEventListener("click", () => {
   window.scrollTo({ top: 0, behavior: "smooth" });
 });
 
+setupTabs();
 applyWhatsAppLinks();

--- a/index.html
+++ b/index.html
@@ -8,10 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&family=Orbitron:wght@600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css?v=3">
-...
-<script src="app.js?v=3"></script>
-
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <div class="bg-effects" aria-hidden="true"></div>
@@ -25,14 +22,7 @@
       sin horarios fijos y coordinando partidas por WhatsApp
     </p>
     <div class="hero-actions">
-      <a id="cta-comunidad"
-   class="btn btn-primary"
-   href="https://chat.whatsapp.com/DvRyA2bxAC67x0ulPQYvCa?mode=gi_t"
-   target="_blank"
-   rel="noopener noreferrer">
-  Unirme a la comunidad
-</a>
-
+      <a id="cta-comunidad" class="btn btn-primary" href="https://chat.whatsapp.com/DvRyA2bxAC67x0ulPQYvCa?mode=gi_t" target="_blank" rel="noopener noreferrer">Unirme a la comunidad</a>
       <a class="btn btn-secondary" href="#ligas">Ver ligas</a>
     </div>
   </header>
@@ -110,30 +100,48 @@
   <div id="modal-overlay" class="modal-overlay" hidden>
     <section id="pes6-panel" class="league-modal" role="dialog" aria-modal="true" aria-labelledby="pes6-modal-title" hidden>
       <button class="close-btn" type="button" aria-label="Cerrar panel">×</button>
-      <img class="modal-banner" src="assets/pes6.png" alt="PES 6 Banner" />
+      <img class="modal-banner" src="assets/pes6.jpg" alt="PES 6 Banner" />
       <h2 id="pes6-modal-title">PES 6 – INFINITY PATCH</h2>
 
-      <h3>¿QUÉ ES?</h3>
-      <p>Liga online de PES 6 utilizando Infinity Patch.</p>
+      <div class="tab-bar" role="tablist" aria-label="Contenido de PES 6">
+        <button class="tab-btn is-active" type="button" role="tab" aria-selected="true" aria-controls="pes6-tab-necesitas" id="pes6-tab-btn-necesitas" data-tab="pes6-tab-necesitas">Qué necesitás para jugar</button>
+        <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-sistema" id="pes6-tab-btn-sistema" data-tab="pes6-tab-sistema">Sistema de liga</button>
+        <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-temporadas" id="pes6-tab-btn-temporadas" data-tab="pes6-tab-temporadas">Temporadas</button>
+      </div>
 
-      <h3>DIVISIONES</h3>
-      <ul>
-        <li>4 divisiones</li>
-        <li>20 jugadores por división</li>
-      </ul>
+      <div class="tab-content">
+        <section class="tab-panel is-active" role="tabpanel" id="pes6-tab-necesitas" aria-labelledby="pes6-tab-btn-necesitas">
+          <h3>¿Qué necesitás para jugar PES 6 en Sudaka League?</h3>
+          <p>Para jugar en la liga PES 6 – Infinity Patch necesitás dos cosas obligatorias:</p>
+          <ol>
+            <li>
+              <strong>Infinity Patch (obligatorio)</strong>
+              <p>Este es el parche oficial que usamos en la liga.</p>
+              <p><a href="https://youtu.be/IsKefVidC4A?si=RBQ4j3CIhWm2N2KJ" target="_blank" rel="noopener noreferrer">https://youtu.be/IsKefVidC4A?si=RBQ4j3CIhWm2N2KJ</a></p>
+              <p class="note-text">La instalación de estadios es OPCIONAL, no es obligatoria.</p>
+            </li>
+            <li>
+              <strong>Configurar el Host Online (obligatorio)</strong>
+              <p><strong>Paso 1:</strong> Crear cuenta en el servidor</p>
+              <p><a href="https://pes6comunidad.trixnodes.com" target="_blank" rel="noopener noreferrer">https://pes6comunidad.trixnodes.com</a></p>
+              <p>En la sección ‘Registro’ creás tu cuenta del server.</p>
 
-      <h3>CÓMO SE JUEGA</h3>
-      <p>Los partidos se juegan cuando dos jugadores coinciden disponibles y coordinan por WhatsApp.</p>
+              <p><strong>Paso 2:</strong> Descargar el Host Selector</p>
+              <p><a href="https://www.mediafire.com/file/cue87dwh4rt8phs/PES6HostSelector.zip/file" target="_blank" rel="noopener noreferrer">https://www.mediafire.com/file/cue87dwh4rt8phs/PES6HostSelector.zip/file</a></p>
 
-      <h3>QUÉ TENÉS QUE INSTALAR</h3>
-      <ul>
-        <li>PES 6</li>
-        <li>Infinity Patch</li>
-      </ul>
+              <p><strong>Paso 3:</strong> Configurar el Host</p>
+              <ol>
+                <li>Descomprimir el archivo</li>
+                <li>Ejecutar PES6HostSelector.exe como administrador</li>
+                <li>Seleccionar el host ‘pes6comunidad’</li>
+                <li>Apretar ‘Salir’</li>
+              </ol>
+            </li>
+          </ol>
+          <p class="highlight-text">Una vez que terminás todo el registro y la instalación: enviarnos tu nombre de usuario de PES6 para sumarte a la lista de espera.</p>
 
-      <h3>MENSAJE OFICIAL PARA NUEVOS JUGADORES</h3>
-      <div class="copy-box">
-        <textarea id="pes6-message" readonly>BIENVENIDO!
+          <div class="copy-box">
+            <textarea id="pes6-message" readonly>BIENVENIDO!
 
 EN ESTE MENSAJE TE DEJO TODO LO NECESARIO PARA EMPEZAR EN LA LIGA SOLO NECESITAS ESTAS DOS COSAS:
 
@@ -151,31 +159,61 @@ Una vez que están registrados, el último paso sería descargar el selector de 
 Una vez instalado lo ejecutan como administrador seleccionan pes6comunidad y apretan en salir
 
 UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES6</textarea>
-        <button class="btn btn-secondary copy-btn" type="button" data-copy-target="pes6-message">📋 Copiar mensaje</button>
+            <button class="btn btn-secondary copy-btn" type="button" data-copy-target="pes6-message">📋 Copiar mensaje</button>
+          </div>
+        </section>
+
+        <section class="tab-panel" role="tabpanel" id="pes6-tab-sistema" aria-labelledby="pes6-tab-btn-sistema" hidden>
+          <ul>
+            <li>Sistema de divisiones</li>
+            <li>Partidos sin horarios fijos: se juegan cuando coinciden dos jugadores</li>
+            <li>Coordinación por la comunidad de WhatsApp</li>
+            <li>Resultados: se reportan en el grupo y se cargan en GesLiga (tablas, posiciones, ascensos)</li>
+            <li>Respeto y juego limpio</li>
+          </ul>
+        </section>
+
+        <section class="tab-panel" role="tabpanel" id="pes6-tab-temporadas" aria-labelledby="pes6-tab-btn-temporadas" hidden>
+          <ul>
+            <li>Cada temporada dura 2 semanas</li>
+            <li>Los equipos NO se eligen: se sortean en vivo por TikTok antes de empezar cada temporada</li>
+            <li>Las temáticas cambian cada temporada: equipos sudamericanos, europeos, selecciones, etc.</li>
+          </ul>
+        </section>
       </div>
 
-      <a id="wa-pes6-modal" class="btn btn-primary" href="#" target="_blank" rel="noopener noreferrer">Ir a la comunidad</a>
+      <a id="wa-pes6-modal" class="btn btn-primary" href="#" target="_blank" rel="noopener noreferrer">Unirme a la comunidad</a>
     </section>
 
     <section id="sf-panel" class="league-modal" role="dialog" aria-modal="true" aria-labelledby="sf-modal-title" hidden>
       <button class="close-btn" type="button" aria-label="Cerrar panel">×</button>
-      <img class="modal-banner" src="assets/sfii.png" alt="Street Fighter II Banner" />
+      <img class="modal-banner" src="assets/sfii.jpg" alt="Street Fighter II Banner" />
       <h2 id="sf-modal-title">STREET FIGHTER II – FIGHTCADE</h2>
 
-      <h3>¿QUÉ ES?</h3>
-      <p>Liga 1 vs 1 de Street Fighter II jugada en Fightcade.</p>
+      <div class="tab-bar" role="tablist" aria-label="Contenido de Street Fighter II">
+        <button class="tab-btn is-active" type="button" role="tab" aria-selected="true" aria-controls="sf-tab-necesitas" id="sf-tab-btn-necesitas" data-tab="sf-tab-necesitas">Qué necesitás para jugar</button>
+        <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="sf-tab-sistema" id="sf-tab-btn-sistema" data-tab="sf-tab-sistema">Sistema de liga</button>
+        <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="sf-tab-temporadas" id="sf-tab-btn-temporadas" data-tab="sf-tab-temporadas">Temporadas</button>
+      </div>
 
-      <h3>DIVISIONES</h3>
-      <ul>
-        <li>Primera División (en inauguración)</li>
-      </ul>
+      <div class="tab-content">
+        <section class="tab-panel is-active" role="tabpanel" id="sf-tab-necesitas" aria-labelledby="sf-tab-btn-necesitas">
+          <h3>¿Qué necesitás para jugar Street Fighter II en Sudaka League?</h3>
+          <ol>
+            <li>
+              <strong>Instalar Fightcade y el juego (obligatorio)</strong>
+              <p><a href="https://www.youtube.com/watch?v=tM5yVYoY-7w&t=126s" target="_blank" rel="noopener noreferrer">https://www.youtube.com/watch?v=tM5yVYoY-7w&t=126s</a></p>
+              <p class="highlight-text">Este video SOLO explica la instalación. El funcionamiento de la liga se explica en otra pestaña.</p>
+            </li>
+            <li>
+              <strong>Entrar al salón correcto (obligatorio)</strong>
+              <p>Todos los partidos de liga se juegan exclusivamente en el salón:</p>
+              <p><strong>#STREET FIGHTER II – CHAMPION EDITION</strong></p>
+            </li>
+          </ol>
 
-      <h3>DÓNDE SE JUEGA</h3>
-      <p>Salón obligatorio de Fightcade: #STREET FIGHTER II – CHAMPION EDITION</p>
-
-      <h3>MENSAJE OFICIAL DE LA LIGA</h3>
-      <div class="copy-box">
-        <textarea id="sf-message" readonly>🔥 BIENVENIDO A LA LIGA DE STREET FIGHTER II – SUDAKA LEAGUE 🔥
+          <div class="copy-box">
+            <textarea id="sf-message" readonly>🔥 BIENVENIDO A LA LIGA DE STREET FIGHTER II – SUDAKA LEAGUE 🔥
 
 📹 VIDEO DE INSTALACIÓN (OBLIGATORIO)
 Este video explica únicamente cómo instalar y configurar Fightcade y el juego: https://www.youtube.com/watch?v=tM5yVYoY-7w&t=126s
@@ -204,10 +242,31 @@ La liga se juega en Fightcade con Street Fighter II.
 Competir, sumar puntos y escalar posiciones.
 
 🔥 Bienvenido a Sudaka League – Street Fighter II 🔥</textarea>
-        <button class="btn btn-secondary copy-btn" type="button" data-copy-target="sf-message">📋 Copiar mensaje</button>
+            <button class="btn btn-secondary copy-btn" type="button" data-copy-target="sf-message">📋 Copiar mensaje</button>
+          </div>
+        </section>
+
+        <section class="tab-panel" role="tabpanel" id="sf-tab-sistema" aria-labelledby="sf-tab-btn-sistema" hidden>
+          <ul>
+            <li>Liga 1 vs 1</li>
+            <li>Sin horarios fijos, se coordina por WhatsApp</li>
+            <li>Se juega en Fightcade dentro del salón oficial</li>
+            <li>Resultados: se reportan y se cargan en GesLiga</li>
+            <li>Ranking / posiciones oficiales</li>
+            <li>Respeto y juego limpio</li>
+          </ul>
+        </section>
+
+        <section class="tab-panel" role="tabpanel" id="sf-tab-temporadas" aria-labelledby="sf-tab-btn-temporadas" hidden>
+          <ul>
+            <li>Cada temporada dura 2 semanas</li>
+            <li>Los jugadores eligen colores que los representan</li>
+            <li>Los personajes son libres para todos: cualquiera puede usar cualquier personaje en cada partida</li>
+          </ul>
+        </section>
       </div>
 
-      <a id="wa-sf-modal" class="btn btn-primary" href="#" target="_blank" rel="noopener noreferrer">Ir a la comunidad</a>
+      <a id="wa-sf-modal" class="btn btn-primary" href="#" target="_blank" rel="noopener noreferrer">Unirme a la comunidad</a>
     </section>
   </div>
 

--- a/styles.css
+++ b/styles.css
@@ -352,6 +352,79 @@ summary:focus-visible,
 }
 
 
+
+.tab-bar {
+  display: flex;
+  gap: 0.55rem;
+  margin: 1rem 0 1.1rem;
+  padding-bottom: 0.35rem;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.tab-btn {
+  border: 1px solid rgba(106, 178, 255, 0.35);
+  background: rgba(6, 22, 47, 0.72);
+  color: #ddecff;
+  padding: 0.62rem 0.85rem;
+  border-radius: 0.65rem;
+  font-weight: 700;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: border-color 200ms ease, box-shadow 220ms ease, transform 180ms ease;
+}
+
+.tab-btn:hover,
+.tab-btn:focus-visible {
+  border-color: var(--line-strong);
+  box-shadow: var(--glow);
+  transform: translateY(-1px);
+}
+
+.tab-btn.is-active {
+  border-color: rgba(129, 198, 255, 0.9);
+  background: linear-gradient(180deg, rgba(56, 117, 206, 0.42), rgba(13, 33, 67, 0.82));
+  box-shadow: var(--glow);
+}
+
+.tab-content {
+  position: relative;
+}
+
+.tab-panel {
+  animation: tab-panel-in 220ms ease;
+}
+
+.tab-panel p,
+.tab-panel li {
+  line-height: 1.62;
+  color: var(--text-main);
+}
+
+.note-text {
+  color: var(--text-soft);
+  font-style: italic;
+}
+
+.highlight-text {
+  border: 1px solid rgba(110, 177, 255, 0.45);
+  background: rgba(12, 32, 66, 0.72);
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.75rem;
+  box-shadow: inset 0 0 0 1px rgba(72, 130, 214, 0.2);
+}
+
+@keyframes tab-panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @media (max-width: 759px) {
   .panel-section,
   .faq {
@@ -361,6 +434,10 @@ summary:focus-visible,
   .panel-section h2 {
     margin-bottom: 1.05rem;
     padding-inline: 0.45rem;
+  }
+
+  .tab-btn {
+    font-size: 0.92rem;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Añadir una barra de pestañas dentro de cada panel/modal de liga para mostrar 3 secciones (`Qué necesitás para jugar`, `Sistema de liga`, `Temporadas`) manteniendo la estética actual (gaming azul/glow) y sin frameworks.
- Garantizar que la experiencia de apertura/cierre de modal y la funcionalidad existente de `Copiar mensaje` sigan funcionando igual en todas las plataformas y en mobile (scroll horizontal para tabs).

### Description
- Actualicé `index.html` para introducir una `tab-bar` y tres `tab-panel` por liga (PES6 y SFII) con el contenido exacto solicitado y links visibles, dejando `Qué necesitás para jugar` como pestaña por defecto.
- Añadí estilos en `styles.css` para la barra de tabs, estados activos, animación suave (`fade/slide`) al cambiar de sección y comportamiento móvil con scroll horizontal para las pestañas.
- Extendí `app.js` con la lógica de tabs: `activateTab`, `setupTabs`, `resetModalToDefaultTab`, y un pequeño ajuste en el `focus-trap` para ignorar elementos ocultos; además se mantiene la lógica previa de apertura/cierre de modales y la función de copiar al portapapeles.
- Mantengo el CTA de comunidad centralizado con `applyWhatsAppLinks` para no crear botones por liga y preservé la accesibilidad (`aria-*`) en los botones de pestañas y paneles.

### Testing
- Verifiqué la sintaxis de JS con `node --check app.js` (resultado: OK).
- Levanté un servidor estático local con `python3 -m http.server 4173` y validé visualmente los modales en navegador.
- Ejecuté un script de Playwright que abrió los modales, cambió entre pestañas y guardó capturas de pantalla (resultados generados: `browser:/tmp/codex_browser_invocations/.../artifacts/artifacts/pes6-tabs.png` y `browser:/tmp/codex_browser_invocations/.../artifacts/artifacts/sf-tabs.png`) y la navegación/acciones sobre tabs funcionaron correctamente.
- Todos los pasos automáticos indicados arriba finalizaron sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986765934648332a8933c72aa273072)