### PR TITLE
Mejora visual del bloque “SISTEMA DE LIGA” para indicar clic

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,11 @@
         aria-controls="sistema-panel"
         data-target="sistema-panel"
       >
-        <h2 id="sistema-liga-title">SISTEMA DE LIGA</h2>
+        <div class="system-panel-header">
+          <h2 id="sistema-liga-title">SISTEMA DE LIGA</h2>
+          <span class="system-panel-indicator" aria-hidden="true">↗</span>
+        </div>
+        <p class="system-panel-hint">Click para ver reglas</p>
         <p>Revisá reglas, puntajes y formatos por liga en un panel separado por pestañas.</p>
       </article>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -429,14 +429,56 @@ summary:focus-visible,
 
 .system-panel-trigger {
   cursor: pointer;
-  transition: transform 180ms ease, border-color 220ms ease, box-shadow 220ms ease;
+  border-color: rgba(123, 196, 255, 0.62);
+  background: rgba(14, 30, 58, 0.9);
+  transition: transform 180ms ease, border-color 220ms ease, box-shadow 220ms ease, background-color 220ms ease;
+}
+
+.system-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.system-panel-header h2 {
+  margin-bottom: 0;
+}
+
+.system-panel-indicator {
+  font-size: clamp(1rem, 2.7vw, 1.2rem);
+  color: #b9ddff;
+  text-shadow: 0 0 0.45rem rgba(110, 192, 255, 0.5);
+  transition: color 220ms ease, text-shadow 220ms ease, transform 220ms ease;
+}
+
+.system-panel-hint {
+  margin: 0.45rem 0 0.7rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+  letter-spacing: 0.015em;
+  color: #c5d9f7;
+  opacity: 0.8;
 }
 
 .system-panel-trigger:hover,
 .system-panel-trigger:focus-visible {
   transform: translateY(-2px);
   border-color: var(--line-strong);
-  box-shadow: var(--glow), 0 0 1.2rem rgba(90, 170, 255, 0.24);
+  background: rgba(18, 38, 72, 0.94);
+  box-shadow: 0 0 1.1rem rgba(108, 191, 255, 0.42), 0 0 1.8rem rgba(90, 170, 255, 0.28);
+}
+
+.system-panel-trigger:hover .system-panel-indicator,
+.system-panel-trigger:focus-visible .system-panel-indicator {
+  color: #ddf0ff;
+  text-shadow: 0 0 0.8rem rgba(130, 206, 255, 0.9);
+  transform: translateX(2px);
+}
+
+.system-panel-trigger:focus-visible {
+  outline: 2px solid #8ec5ff;
+  outline-offset: 3px;
 }
 
 .system-modal {
@@ -497,6 +539,11 @@ summary:focus-visible,
 
   .tab-btn {
     font-size: 0.92rem;
+  }
+
+  .system-panel-trigger {
+    border-width: 2px;
+    box-shadow: inset 0 0 0 1px rgba(80, 145, 225, 0.25), 0 0 1rem rgba(82, 156, 235, 0.18);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Hacer que el bloque “SISTEMA DE LIGA” se note claramente clickeable manteniendo la estética esports. 
- Añadir una pista visual y textual (`↗` y “Click para ver reglas”) para mejorar la affordance sin cambiar la lógica del modal. 
- Mejorar la accesibilidad para navegación por teclado con un estado `:focus-visible` destacado y asegurar visibilidad en mobile con borde más marcado.

### Description
- Actualicé `index.html` para envolver el título en un contenedor `.system-panel-header`, añadir el indicador `↗` y el texto guía `<p class="system-panel-hint">Click para ver reglas</p>`.
- Modifiqué `styles.css` para dar a `.system-panel-trigger` un `cursor: pointer`, fondo/base más visible y transiciones más completas para interacción visual.
- Añadí reglas CSS para `.system-panel-header`, `.system-panel-indicator` y `.system-panel-hint` que gestionan la disposición, tamaño del icono, brillo y la pista sutil bajo el título.
- Implementé estados de `:hover` / `:focus-visible` que aplican `transform: translateY(-2px)`, borde/glow más brillante, fondo más claro y animación del indicador; y añadí un `:focus-visible` con `outline` para teclado.
- Añadí estilos específicos para mobile que aumentan `border-width` / box-shadow por defecto para que el bloque sea más evidente en pantallas pequeñas.

### Testing
- Ejecuté `git diff --check` y no reportó errores de whitespace ni problemas de diff. (éxito)
- Inicié un servidor local con `python -m http.server 4173` para validar la página servida en `http://127.0.0.1:4173/index.html` y el servidor quedó disponible durante la verificación. (éxito)
- Intenté generar una captura con Playwright para validar visualmente el hover/focus, pero la instancia de Chromium en el entorno falló al iniciarse con un `SIGSEGV`, por lo que la captura automatizada no pudo completarse. (fallido)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698683e2d5b4833280732ce863b7f61a)