### PR TITLE
Add ESTADO DE TEMPORADA section with PES6 countdown and SFII status

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,9 @@
 const WHATSAPP_COMUNIDAD = "https://chat.whatsapp.com/DvRyA2bxAC67x0ulPQYvCa?mode=gi_t";
+const PES6_SEASON_NAME = "Temporada 23";
+const PES6_SEASON_END = "2026-02-07T23:59:00-03:00";
+const SF_SEASON_NAME = "Temporada 1";
+const SF_SEASON_STATUS = "EN ESPERA";
+const SF_SEASON_NOTE = "En espera hasta completar cupos.";
 
 const overlay = document.getElementById("modal-overlay");
 const modals = [...document.querySelectorAll(".league-modal")];
@@ -6,11 +11,71 @@ const triggers = [...document.querySelectorAll(".modal-trigger")];
 const closeButtons = [...document.querySelectorAll(".close-btn")];
 const copyButtons = [...document.querySelectorAll(".copy-btn")];
 const backToTopButton = document.getElementById("back-to-top");
+const pes6Status = document.getElementById("pes6Status");
+const pes6Countdown = document.getElementById("pes6Countdown");
+const pes6SeasonName = document.getElementById("pes6SeasonName");
+const sfStatus = document.getElementById("sfStatus");
+const sfSeasonName = document.getElementById("sfSeasonName");
+const sfSeasonNote = document.getElementById("sfSeasonNote");
+
 
 let activeModal = null;
 let lastFocusedElement = null;
 
 // Asignación centralizada de links editables.
+
+function setPes6EndedState() {
+  pes6Status.textContent = "FINALIZADA";
+  pes6Status.classList.remove("season-badge-active");
+  pes6Status.classList.add("season-badge-ended");
+  pes6Countdown.textContent = "Temporada finalizada";
+}
+
+function getCountdownText() {
+  const msRemaining = new Date(PES6_SEASON_END).getTime() - Date.now();
+
+  if (msRemaining <= 0) {
+    return null;
+  }
+
+  const totalMinutes = Math.floor(msRemaining / (1000 * 60));
+  const totalHours = Math.floor(msRemaining / (1000 * 60 * 60));
+  const totalDays = Math.floor(msRemaining / (1000 * 60 * 60 * 24));
+
+  if (msRemaining >= 1000 * 60 * 60 * 48) {
+    return `${totalDays} días`;
+  }
+
+  if (msRemaining >= 1000 * 60 * 60 * 2) {
+    return `${totalHours} horas`;
+  }
+
+  return `${Math.max(totalMinutes, 0)} min`;
+}
+
+function updateSeasonStatus() {
+  if (!pes6Status || !pes6Countdown || !pes6SeasonName || !sfStatus || !sfSeasonName || !sfSeasonNote) {
+    return;
+  }
+
+  pes6SeasonName.textContent = PES6_SEASON_NAME;
+  sfSeasonName.textContent = SF_SEASON_NAME;
+  sfStatus.textContent = SF_SEASON_STATUS;
+  sfSeasonNote.textContent = SF_SEASON_NOTE;
+
+  const countdownText = getCountdownText();
+
+  if (!countdownText) {
+    setPes6EndedState();
+    return;
+  }
+
+  pes6Status.textContent = "ACTIVA";
+  pes6Status.classList.add("season-badge-active");
+  pes6Status.classList.remove("season-badge-ended");
+  pes6Countdown.textContent = countdownText;
+}
+
 function applyWhatsAppLinks() {
   const links = {
     "cta-comunidad": WHATSAPP_COMUNIDAD,
@@ -188,3 +253,5 @@ backToTopButton.addEventListener("click", () => {
 
 setupTabs();
 applyWhatsAppLinks();
+updateSeasonStatus();
+setInterval(updateSeasonStatus, 30000);

--- a/index.html
+++ b/index.html
@@ -37,6 +37,29 @@
       </p>
     </section>
 
+    <section class="section hud-separator season-status" aria-labelledby="season-status-title">
+      <h2 id="season-status-title">ESTADO DE TEMPORADA</h2>
+      <div class="season-grid">
+        <article class="season-card" aria-labelledby="pes6-season-title">
+          <div class="season-card-header">
+            <h3 id="pes6-season-title">⚽ PES 6 – Infinity Patch</h3>
+            <span id="pes6Status" class="season-badge season-badge-active">ACTIVA</span>
+          </div>
+          <p id="pes6SeasonName" class="season-title">Temporada 23</p>
+          <p class="season-countdown-label">Finaliza en: <span id="pes6Countdown">Calculando…</span></p>
+        </article>
+
+        <article class="season-card" aria-labelledby="sf-season-title">
+          <div class="season-card-header">
+            <h3 id="sf-season-title">🥊 Street Fighter II – Fightcade</h3>
+            <span id="sfStatus" class="season-badge season-badge-wait">EN ESPERA</span>
+          </div>
+          <p id="sfSeasonName" class="season-title">Temporada 1</p>
+          <p id="sfSeasonNote" class="season-note">En espera hasta completar cupos.</p>
+        </article>
+      </div>
+    </section>
+
     <section id="ligas" class="section hud-separator" aria-labelledby="ligas-title">
       <h2 id="ligas-title">LIGAS</h2>
       <div class="league-grid">

--- a/styles.css
+++ b/styles.css
@@ -212,6 +212,83 @@ summary:focus-visible,
   gap: 1rem;
 }
 
+
+.season-status h2 {
+  margin-bottom: 1.2rem;
+}
+
+.season-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.season-card {
+  background: var(--bg-panel);
+  border: 1px solid rgba(100, 173, 255, 0.42);
+  border-radius: 1rem;
+  padding: clamp(1.1rem, 3.5vw, 1.5rem);
+  box-shadow: inset 0 0 0 1px rgba(54, 101, 168, 0.24), 0 10px 28px rgba(1, 8, 22, 0.45);
+  transition: transform 180ms ease, border-color 220ms ease, box-shadow 220ms ease;
+}
+
+.season-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+}
+
+.season-card h3 {
+  margin: 0;
+}
+
+.season-title,
+.season-countdown-label,
+.season-note {
+  margin: 0.7rem 0 0;
+  color: var(--text-soft);
+}
+
+.season-countdown-label {
+  color: var(--text-main);
+}
+
+.season-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.3rem 0.65rem;
+  font-family: "Orbitron", "Inter", sans-serif;
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  font-weight: 700;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.season-badge-active {
+  color: #d9f2ff;
+  border-color: rgba(109, 218, 255, 0.75);
+  background: linear-gradient(180deg, rgba(24, 128, 173, 0.46), rgba(8, 62, 95, 0.72));
+  box-shadow: 0 0 0.75rem rgba(96, 220, 255, 0.35);
+}
+
+.season-badge-wait {
+  color: #fce5ff;
+  border-color: rgba(220, 145, 255, 0.6);
+  background: linear-gradient(180deg, rgba(126, 55, 177, 0.45), rgba(64, 26, 102, 0.76));
+  box-shadow: 0 0 0.75rem rgba(186, 124, 255, 0.28);
+}
+
+.season-badge-ended {
+  color: #ffe8e8;
+  border-color: rgba(255, 133, 133, 0.7);
+  background: linear-gradient(180deg, rgba(155, 45, 45, 0.46), rgba(87, 19, 19, 0.78));
+  box-shadow: 0 0 0.75rem rgba(255, 101, 101, 0.28);
+}
+
 .league-card {
   overflow: hidden;
   cursor: pointer;
@@ -563,6 +640,16 @@ summary:focus-visible,
 
   .whatsapp-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .season-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .season-card:hover {
+    transform: translateY(-3px);
+    border-color: var(--line-strong);
+    box-shadow: 0 0 1.4rem rgba(99, 184, 255, 0.24);
   }
 
   .league-card img,


### PR DESCRIPTION
### Motivation
- Mostrar en la home un bloque visible con el estado de temporada de las ligas, manteniendo la estética gaming/esports del sitio y colocándolo entre “¿QUÉ ES SUDAKA LEAGUE?” y “LIGAS”.
- Diferenciar el estado de cada liga: PES6 con countdown hasta la fecha final, y SFII con estado "EN ESPERA" y nota, sin countdown.

### Description
- Se agregó la sección `ESTADO DE TEMPORADA` en `index.html` con dos cards y placeholders con IDs: `#pes6Countdown`, `#pes6Status`, `#pes6SeasonName`, `#sfStatus`, `#sfSeasonName`, `#sfSeasonNote`.
- Se añadieron estilos en `styles.css` para las cards, badges (clases `season-badge-active`, `season-badge-wait`, `season-badge-ended`), layout mobile-first y grid a 2 columnas en desktop, y hover sutil coherente con el sitio.
- En `app.js` se definieron las constantes editables solicitadas (`PES6_SEASON_NAME`, `PES6_SEASON_END` — hardcodeada como `2026-02-07T23:59:00-03:00` en zona UTC-03:00 —, `SF_SEASON_NAME`, `SF_SEASON_STATUS`, `SF_SEASON_NOTE`) y se implementó la lógica del countdown que:
  - se evalúa al cargar y se actualiza cada 30s con `setInterval`,
  - muestra `X días` cuando faltan >= 48h, `X horas` cuando faltan < 48h, `X min` cuando faltan < 2h,
  - y al expirar cambia el badge a `FINALIZADA` y muestra `Temporada finalizada`.

### Testing
- Se ejecutó `node --check app.js` para validar sintaxis JavaScript y pasó correctamente.
- Se sirvió la carpeta con `python3 -m http.server 4173` y se verificó que la página y activos respondieran (HTTP 200) para inspección visual; la verificación fue satisfactoria.
- Se generó una captura de pantalla automática con Playwright apuntando a `http://127.0.0.1:4173` para validar render y estilos, y la captura se produjo con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69868a03285083329a40a3d59d569580)