### PR TITLE
Agregar bloque "CUPOS DISPONIBLES" en Estado de Temporada

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,7 @@
+// === CONFIGURACIÓN DE CUPOS (EDITAR SOLO ESTO) ===
+const PES6_CUPOS_LIBRES = 8; // 4ta división
+const SF_CUPOS_LIBRES = 3;   // Street Fighter II
+
 const WHATSAPP_COMUNIDAD = "https://chat.whatsapp.com/DvRyA2bxAC67x0ulPQYvCa?mode=gi_t";
 const PES6_SEASON_NAME = "Temporada 23";
 const PES6_SEASON_END = "2026-02-07T23:59:00-03:00";
@@ -17,6 +21,12 @@ const pes6SeasonName = document.getElementById("pes6SeasonName");
 const sfStatus = document.getElementById("sfStatus");
 const sfSeasonName = document.getElementById("sfSeasonName");
 const sfSeasonNote = document.getElementById("sfSeasonNote");
+const pes6SlotsCard = document.getElementById("pes6SlotsCard");
+const pes6SlotsBadge = document.getElementById("pes6SlotsBadge");
+const pes6SlotsCount = document.getElementById("pes6SlotsCount");
+const sfSlotsCard = document.getElementById("sfSlotsCard");
+const sfSlotsBadge = document.getElementById("sfSlotsBadge");
+const sfSlotsCount = document.getElementById("sfSlotsCount");
 
 
 let activeModal = null;
@@ -74,6 +84,46 @@ function updateSeasonStatus() {
   pes6Status.classList.add("season-badge-active");
   pes6Status.classList.remove("season-badge-ended");
   pes6Countdown.textContent = countdownText;
+}
+
+function updateSlotsStatus() {
+  const slotsElements = [
+    pes6SlotsCard,
+    pes6SlotsBadge,
+    pes6SlotsCount,
+    sfSlotsCard,
+    sfSlotsBadge,
+    sfSlotsCount
+  ];
+
+  if (slotsElements.some((element) => !element)) {
+    return;
+  }
+
+  const slotsConfig = [
+    {
+      slots: PES6_CUPOS_LIBRES,
+      card: pes6SlotsCard,
+      badge: pes6SlotsBadge,
+      count: pes6SlotsCount
+    },
+    {
+      slots: SF_CUPOS_LIBRES,
+      card: sfSlotsCard,
+      badge: sfSlotsBadge,
+      count: sfSlotsCount
+    }
+  ];
+
+  slotsConfig.forEach(({ slots, card, badge, count }) => {
+    const isOpen = slots > 0;
+    const safeSlots = Math.max(0, slots);
+
+    card.classList.toggle("status-open", isOpen);
+    card.classList.toggle("status-closed", !isOpen);
+    badge.innerHTML = `<span class="slots-led" aria-hidden="true">●</span> ${isOpen ? "ABIERTA" : "COMPLETA"}`;
+    count.textContent = `${safeSlots} cupos libres`;
+  });
 }
 
 function applyWhatsAppLinks() {
@@ -254,4 +304,5 @@ backToTopButton.addEventListener("click", () => {
 setupTabs();
 applyWhatsAppLinks();
 updateSeasonStatus();
+updateSlotsStatus();
 setInterval(updateSeasonStatus, 30000);

--- a/index.html
+++ b/index.html
@@ -58,6 +58,28 @@
           <p id="sfSeasonNote" class="season-note">En espera hasta completar cupos.</p>
         </article>
       </div>
+
+      <div class="slots-header-wrap">
+        <h3 class="slots-title">CUPOS DISPONIBLES</h3>
+      </div>
+
+      <div class="slots-grid" aria-label="Cupos disponibles por liga">
+        <article id="pes6SlotsCard" class="slots-card" aria-labelledby="pes6-slots-title">
+          <div class="slots-card-header">
+            <h4 id="pes6-slots-title">PES 6 – 4ta División</h4>
+            <span id="pes6SlotsBadge" class="slots-badge">—</span>
+          </div>
+          <p id="pes6SlotsCount" class="slots-count">0 cupos libres</p>
+        </article>
+
+        <article id="sfSlotsCard" class="slots-card" aria-labelledby="sf-slots-title">
+          <div class="slots-card-header">
+            <h4 id="sf-slots-title">Street Fighter II</h4>
+            <span id="sfSlotsBadge" class="slots-badge">—</span>
+          </div>
+          <p id="sfSlotsCount" class="slots-count">0 cupos libres</p>
+        </article>
+      </div>
     </section>
 
     <section id="ligas" class="section hud-separator" aria-labelledby="ligas-title">

--- a/styles.css
+++ b/styles.css
@@ -646,6 +646,10 @@ summary:focus-visible,
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .slots-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .season-card:hover {
     transform: translateY(-3px);
     border-color: var(--line-strong);
@@ -679,4 +683,113 @@ summary:focus-visible,
 /* Para que no se recorte raro dentro de la card */
 .league-card{
   overflow: hidden;
+}
+
+.slots-header-wrap {
+  margin-top: 1.3rem;
+}
+
+.slots-title {
+  margin: 0;
+  font-size: clamp(1rem, 2.6vw, 1.2rem);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #dbe9ff;
+}
+
+.slots-grid {
+  margin-top: 0.85rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.slots-card {
+  background: rgba(8, 21, 47, 0.82);
+  border: 1px solid rgba(96, 170, 255, 0.4);
+  border-radius: 1rem;
+  padding: clamp(1rem, 3.5vw, 1.35rem);
+  box-shadow: inset 0 0 0 1px rgba(50, 91, 150, 0.23), 0 10px 24px rgba(1, 8, 22, 0.42);
+  transition: border-color 220ms ease, box-shadow 220ms ease;
+}
+
+.slots-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.slots-card h4 {
+  margin: 0;
+  font-size: clamp(0.95rem, 2.8vw, 1.08rem);
+}
+
+.slots-count {
+  margin: 0.75rem 0 0;
+  font-family: "Orbitron", "Inter", sans-serif;
+  font-size: clamp(1.15rem, 4.6vw, 1.55rem);
+  letter-spacing: 0.02em;
+}
+
+.slots-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.3rem 0.7rem;
+  font-family: "Orbitron", "Inter", sans-serif;
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  font-weight: 700;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.slots-led {
+  font-size: 0.62rem;
+}
+
+.status-open .slots-badge {
+  color: #eafff4;
+  border-color: rgba(46, 204, 113, 0.72);
+  background: linear-gradient(180deg, rgba(32, 171, 95, 0.42), rgba(12, 82, 48, 0.78));
+  box-shadow: 0 0 0.8rem rgba(46, 204, 113, 0.28);
+}
+
+.status-closed .slots-badge {
+  color: #fff0ee;
+  border-color: rgba(231, 76, 60, 0.72);
+  background: linear-gradient(180deg, rgba(185, 62, 49, 0.45), rgba(103, 30, 23, 0.82));
+  box-shadow: 0 0 0.8rem rgba(231, 76, 60, 0.28);
+}
+
+.status-open {
+  border-color: rgba(46, 204, 113, 0.56);
+  box-shadow: inset 0 0 0 1px rgba(50, 150, 98, 0.25), 0 0 1rem rgba(46, 204, 113, 0.18);
+  animation: slots-open-pulse 2.8s ease-in-out infinite;
+}
+
+.status-closed {
+  border-color: rgba(231, 76, 60, 0.56);
+  box-shadow: inset 0 0 0 1px rgba(173, 70, 60, 0.25), 0 0 1rem rgba(231, 76, 60, 0.18);
+  animation: slots-closed-pulse 2.8s ease-in-out infinite;
+}
+
+@keyframes slots-open-pulse {
+  0%, 100% {
+    box-shadow: inset 0 0 0 1px rgba(50, 150, 98, 0.24), 0 0 0.85rem rgba(46, 204, 113, 0.14);
+  }
+  50% {
+    box-shadow: inset 0 0 0 1px rgba(50, 150, 98, 0.26), 0 0 1.15rem rgba(46, 204, 113, 0.24);
+  }
+}
+
+@keyframes slots-closed-pulse {
+  0%, 100% {
+    box-shadow: inset 0 0 0 1px rgba(173, 70, 60, 0.24), 0 0 0.85rem rgba(231, 76, 60, 0.14);
+  }
+  50% {
+    box-shadow: inset 0 0 0 1px rgba(173, 70, 60, 0.26), 0 0 1.15rem rgba(231, 76, 60, 0.24);
+  }
 }


### PR DESCRIPTION
### Motivation
- Mostrar de forma clara y editable la cantidad de cupos por liga dentro de la sección existente `ESTADO DE TEMPORADA` usando solo HTML/CSS/JS puro y manteniendo la estética esports del proyecto.
- Permitir que la información se actualice únicamente cambiando números en la parte superior de `app.js` para facilitar mantenimiento rápido.

### Description
- Añadí el bloque `CUPOS DISPONIBLES` en `index.html` con dos cards: `PES 6 – 4ta División` y `Street Fighter II`, incluyendo placeholders semánticos (`#pes6SlotsCard`, `#pes6SlotsBadge`, `#pes6SlotsCount`, `#sfSlotsCard`, `#sfSlotsBadge`, `#sfSlotsCount`).
- Creé la sección de configuración editable al inicio de `app.js` con las constantes `PES6_CUPOS_LIBRES` y `SF_CUPOS_LIBRES` y añadí la función `updateSlotsStatus()` que actualiza el texto y aplica las clases dinámicas `.status-open` / `.status-closed` y el badge LED (`●`) con texto `ABIERTA`/`COMPLETA` según el valor de cupos.
- Conecté `updateSlotsStatus()` al arranque de la app para pintar el estado al cargar la página y usé solo manipulación DOM ligera sin frameworks.
- Añadí estilos en `styles.css` para badges verdes/rojos, glow sutil (pulse), layout mobile-first y responsive (2 columnas en desktop) sin hardcodear colores en el HTML; se usan las clases `status-open` y `status-closed` para controlar visuales.

### Testing
- Ejecuté `node --check app.js` para validar sintaxis de JavaScript y reportó sin errores (éxito). 
- Levanté un servidor local con `python3 -m http.server` y validé visualmente el resultado; la página respondió correctamente y se generó una captura de pantalla mediante la herramienta de navegador automática (Playwright) (éxito).
- Verifiqué que al ajustar las constantes en la sección `// === CONFIGURACIÓN DE CUPOS (EDITAR SOLO ESTO) ===` los badges, el texto `N cupos libres` y las clases `.status-open`/`.status-closed` cambian según lo esperado (test manual via servidor local, éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69868e62935c833294dbe41fba2534df)