### PR TITLE
Agregar pestaña dinámica “Palmarés / Campeones” en el modal de PES 6

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,60 @@ const SF_SEASON_NAME = "Temporada 1";
 const SF_SEASON_STATUS = "EN ESPERA";
 const SF_SEASON_NOTE = "En espera hasta completar cupos.";
 
+const PES6_PALMARES = {
+  divisiones: [
+    {
+      nombre: "División 1",
+      trofeo: "assets/trofeo_div1.png",
+      campeones: ["A confirmar"]
+    },
+    {
+      nombre: "División 2",
+      trofeo: "assets/trofeo_div2.png",
+      campeones: ["A confirmar"]
+    },
+    {
+      nombre: "División 3",
+      trofeo: "assets/trofeo_div3.png",
+      campeones: ["A confirmar"]
+    },
+    {
+      nombre: "División 4",
+      trofeo: "assets/trofeo_div4.png",
+      campeones: ["A confirmar"]
+    }
+  ],
+  copas: [
+    {
+      nombre: "Copa Interdivisional",
+      trofeo: "assets/trofeo_interdiv.png",
+      campeones: ["A confirmar"]
+    },
+    {
+      nombre: "Superfinal",
+      trofeo: "assets/trofeo_superfinal.png",
+      campeones: ["A confirmar"]
+    },
+    {
+      nombre: "Interliga",
+      trofeo: "assets/trofeo_interliga.png",
+      campeones: ["A confirmar"]
+    }
+  ],
+  individuales: [
+    {
+      nombre: "Balón de Oro",
+      trofeo: "assets/trofeo_balon_oro.png",
+      ganadores: ["A confirmar"]
+    },
+    {
+      nombre: "Premio Puskás",
+      trofeo: "assets/trofeo_puskas.png",
+      ganadores: ["A confirmar"]
+    }
+  ]
+};
+
 const overlay = document.getElementById("modal-overlay");
 const modals = [...document.querySelectorAll(".league-modal")];
 const triggers = [...document.querySelectorAll(".modal-trigger")];
@@ -295,7 +349,77 @@ backToTopButton.addEventListener("click", () => {
   window.scrollTo({ top: 0, behavior: "smooth" });
 });
 
+function createPalmaresCard(item, winnersKey) {
+  const card = document.createElement("article");
+  card.className = "palmares-card";
+
+  const title = document.createElement("h4");
+  title.textContent = item.nombre;
+
+  const trophy = document.createElement("img");
+  trophy.className = "palmares-trophy";
+  trophy.src = item.trofeo;
+  trophy.alt = `Trofeo ${item.nombre}`;
+  trophy.loading = "lazy";
+
+  const winners = document.createElement("ul");
+  winners.className = "palmares-winners";
+
+  item[winnersKey].forEach((winner) => {
+    const winnerItem = document.createElement("li");
+    winnerItem.textContent = winner;
+    winners.appendChild(winnerItem);
+  });
+
+  card.append(title, trophy, winners);
+  return card;
+}
+
+function renderPalmares() {
+  const container = document.getElementById("pes6-palmares-content");
+  if (!container) return;
+
+  const sections = [
+    {
+      title: "Campeones por División",
+      items: PES6_PALMARES.divisiones,
+      winnersKey: "campeones"
+    },
+    {
+      title: "Copas",
+      items: PES6_PALMARES.copas,
+      winnersKey: "campeones"
+    },
+    {
+      title: "Premios Individuales",
+      items: PES6_PALMARES.individuales,
+      winnersKey: "ganadores"
+    }
+  ];
+
+  container.replaceChildren();
+
+  sections.forEach((section) => {
+    const block = document.createElement("section");
+    block.className = "palmares-block";
+
+    const heading = document.createElement("h3");
+    heading.textContent = section.title;
+
+    const grid = document.createElement("div");
+    grid.className = "palmares-grid";
+
+    section.items.forEach((item) => {
+      grid.appendChild(createPalmaresCard(item, section.winnersKey));
+    });
+
+    block.append(heading, grid);
+    container.appendChild(block);
+  });
+}
+
 setupTabs();
+renderPalmares();
 applyWhatsAppLinks();
 updateSeasonStatus();
 updateSlotsStatus();

--- a/index.html
+++ b/index.html
@@ -148,6 +148,7 @@
         <button class="tab-btn is-active" type="button" role="tab" aria-selected="true" aria-controls="pes6-tab-necesitas" id="pes6-tab-btn-necesitas" data-tab="pes6-tab-necesitas">Qué necesitás para jugar</button>
         <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-sistema" id="pes6-tab-btn-sistema" data-tab="pes6-tab-sistema">Sistema de liga</button>
         <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-temporadas" id="pes6-tab-btn-temporadas" data-tab="pes6-tab-temporadas">Temporadas</button>
+        <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-palmares" id="pes6-tab-btn-palmares" data-tab="pes6-tab-palmares">Palmarés / Campeones</button>
       </div>
 
       <div class="tab-content">
@@ -220,6 +221,10 @@ UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES
             <li>Los equipos NO se eligen: se sortean en vivo por TikTok antes de empezar cada temporada</li>
             <li>Las temáticas cambian cada temporada: equipos sudamericanos, europeos, selecciones, etc.</li>
           </ul>
+        </section>
+
+        <section class="tab-panel" role="tabpanel" id="pes6-tab-palmares" aria-labelledby="pes6-tab-btn-palmares" hidden>
+          <div id="pes6-palmares-content" class="palmares-layout"></div>
         </section>
       </div>
 

--- a/styles.css
+++ b/styles.css
@@ -540,6 +540,56 @@ summary:focus-visible,
   box-shadow: inset 0 0 0 1px rgba(72, 130, 214, 0.2);
 }
 
+
+.palmares-layout {
+  display: grid;
+  gap: 1rem;
+}
+
+.palmares-block {
+  padding: 1rem;
+  border: 1px solid rgba(110, 177, 255, 0.35);
+  border-radius: 0.85rem;
+  background: rgba(8, 24, 49, 0.72);
+  box-shadow: inset 0 0 0 1px rgba(70, 131, 211, 0.2);
+}
+
+.palmares-block h3 {
+  margin: 0 0 0.8rem;
+}
+
+.palmares-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.palmares-card {
+  display: grid;
+  gap: 0.55rem;
+  align-content: start;
+  padding: 0.8rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(123, 196, 255, 0.3);
+  background: linear-gradient(180deg, rgba(15, 39, 78, 0.78), rgba(7, 20, 42, 0.9));
+}
+
+.palmares-card h4 {
+  margin: 0;
+  font-size: 0.96rem;
+}
+
+.palmares-trophy {
+  width: 56px;
+  height: 56px;
+  object-fit: contain;
+}
+
+.palmares-winners {
+  margin: 0;
+  padding-left: 1rem;
+}
+
 @keyframes tab-panel-in {
   from {
     opacity: 0;


### PR DESCRIPTION
### Motivation
- Añadir el apartado “Palmarés / Campeones” al modal de PES 6 para mostrar campeones y premios de forma dinámica desde JavaScript. 
- Usar únicamente las imágenes de trofeos existentes en `assets/` sin crear ni modificar archivos binarios. 

### Description
- Agregado un nuevo botón/tab y contenedor `#pes6-palmares-content` en `index.html` para la pestaña “Palmarés / Campeones”.
- Implementado el objeto `PES6_PALMARES` en `app.js` con las tres categorías solicitadas (`divisiones`, `copas`, `individuales`) y rutas a los trofeos en `assets/`.
- Añadidas funciones `createPalmaresCard` y `renderPalmares` en `app.js` que generan dinámicamente el HTML de bloques, tarjetas y listas de campeones y se ejecutan al iniciar la app.
- Incorporados estilos en `styles.css` (`.palmares-*`) para mantener la estética existente del sitio y presentar bloques, grillas y tarjetas de trofeos.

### Testing
- Verificación de sintaxis JavaScript con `node --check app.js`, resultado: passed. 
- Levantado servidor local con `python -m http.server 4173` y verificación básica con `curl -I http://127.0.0.1:4173`, resultado: respuesta HTTP 200. 
- Prueba visual automatizada con Playwright que abrió la página, activó el modal PES 6 y la pestaña de palmarés y generó una captura (`artifacts/pes6-palmares.png`), resultado: passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69869f6342b48332a55118a732aabb65)