### PR TITLE
Actualizar palmarés T22 de PES6 y eliminar CTA duplicado en modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,51 +14,53 @@ const PES6_PALMARES = {
     {
       nombre: "División 1",
       trofeo: "assets/trofeo_div1.png",
-      campeones: ["A confirmar"]
+      campeones: ["Edug98"]
     },
     {
       nombre: "División 2",
       trofeo: "assets/trofeo_div2.png",
-      campeones: ["A confirmar"]
+      campeones: ["MartinPalermo"]
     },
     {
       nombre: "División 3",
       trofeo: "assets/trofeo_div3.png",
-      campeones: ["A confirmar"]
+      campeones: ["H09"]
     },
     {
       nombre: "División 4",
       trofeo: "assets/trofeo_div4.png",
-      campeones: ["A confirmar"]
+      campeones: ["Cacherinhooo"]
     }
   ],
   copas: [
     {
       nombre: "Copa Interdivisional",
       trofeo: "assets/trofeo_interdiv.png",
-      campeones: ["A confirmar"]
+      campeones: ["Larrierismo"]
     },
     {
-      nombre: "Superfinal",
+      nombre: "Super Final",
       trofeo: "assets/trofeo_superfinal.png",
-      campeones: ["A confirmar"]
+      campeones: ["Larrierismo"]
     },
     {
-      nombre: "Interliga",
+      nombre: "Final Interliga vs S.F.A",
       trofeo: "assets/trofeo_interliga.png",
-      campeones: ["A confirmar"]
+      campeones: ["Faquuvilla (S.F.A)"]
     }
   ],
   individuales: [
     {
       nombre: "Balón de Oro",
       trofeo: "assets/trofeo_balon_oro.png",
-      ganadores: ["A confirmar"]
+      subtitulo: "Ganador (últimas 3 temporadas)",
+      ganadores: ["Pelufo"]
     },
     {
       nombre: "Premio Puskás",
       trofeo: "assets/trofeo_puskas.png",
-      ganadores: ["A confirmar"]
+      subtitulo: "Ganador (Temporada 22)",
+      ganadores: ["Naxul90"]
     }
   ]
 };
@@ -177,7 +179,6 @@ function updateSlotsStatus() {
 function applyWhatsAppLinks() {
   const links = {
     "cta-comunidad": WHATSAPP_COMUNIDAD,
-    "wa-pes6-modal": WHATSAPP_COMUNIDAD,
     "wa-sf-modal": WHATSAPP_COMUNIDAD
   };
 
@@ -365,13 +366,25 @@ function createPalmaresCard(item, winnersKey, winnerLabel) {
   const winners = document.createElement("ul");
   winners.className = "palmares-winners";
 
-  item[winnersKey].forEach((winner) => {
+  const winnersList = item[winnersKey].filter((winner) => winner && winner.trim() !== "");
+  const safeWinners = winnersList.length ? winnersList : ["A confirmar"];
+
+  safeWinners.forEach((winner) => {
     const winnerItem = document.createElement("li");
     winnerItem.textContent = `${winnerLabel}: ${winner}`;
     winners.appendChild(winnerItem);
   });
 
-  card.append(title, trophy, winners);
+  card.appendChild(title);
+
+  if (item.subtitulo) {
+    const subtitle = document.createElement("p");
+    subtitle.className = "palmares-subtitle";
+    subtitle.textContent = item.subtitulo;
+    card.appendChild(subtitle);
+  }
+
+  card.append(trophy, winners);
   return card;
 }
 
@@ -381,22 +394,24 @@ function renderPalmares() {
 
   const sections = [
     {
-      title: "Últimos campeones por División (Temporada 22)",
+      title: "Campeones por División",
+      subtitle: "Últimos campeones (Temporada 22)",
       items: PES6_PALMARES.divisiones,
       winnersKey: "campeones",
       winnerLabel: "Último campeón"
     },
     {
-      title: "Últimos campeones de Copas (Temporada 22)",
+      title: "Copas",
+      subtitle: "Últimos campeones de copas (Temporada 22)",
       items: PES6_PALMARES.copas,
       winnersKey: "campeones",
       winnerLabel: "Último campeón"
     },
     {
-      title: "Últimos ganadores de Premios (Temporada 22)",
+      title: "Premios individuales",
       items: PES6_PALMARES.individuales,
       winnersKey: "ganadores",
-      winnerLabel: "Último ganador"
+      winnerLabel: "Ganador"
     }
   ];
 
@@ -408,6 +423,14 @@ function renderPalmares() {
 
     const heading = document.createElement("h3");
     heading.textContent = section.title;
+    block.appendChild(heading);
+
+    if (section.subtitle) {
+      const subtitle = document.createElement("p");
+      subtitle.className = "palmares-subtitle";
+      subtitle.textContent = section.subtitle;
+      block.appendChild(subtitle);
+    }
 
     const grid = document.createElement("div");
     grid.className = "palmares-grid";
@@ -416,7 +439,7 @@ function renderPalmares() {
       grid.appendChild(createPalmaresCard(item, section.winnersKey, section.winnerLabel));
     });
 
-    block.append(heading, grid);
+    block.appendChild(grid);
     container.appendChild(block);
   });
 }

--- a/index.html
+++ b/index.html
@@ -228,7 +228,6 @@ UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES
         </section>
       </div>
 
-      <a id="wa-pes6-modal" class="btn btn-primary" href="#" target="_blank" rel="noopener noreferrer">Unirme a la comunidad</a>
     </section>
 
     <section id="sf-panel" class="league-modal" role="dialog" aria-modal="true" aria-labelledby="sf-modal-title" hidden>

--- a/styles.css
+++ b/styles.css
@@ -558,6 +558,12 @@ summary:focus-visible,
   margin: 0 0 0.8rem;
 }
 
+.palmares-subtitle {
+  margin: -0.35rem 0 0.8rem;
+  font-size: 0.9rem;
+  color: var(--text-soft);
+}
+
 .palmares-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));


### PR DESCRIPTION
### Motivation
- Mostrar los campeones reales de la Temporada 22 en la pestaña “Palmarés / Campeones” y aclarar en cada bloque el alcance temporal de los títulos.
- Evitar que el UI muestre "A confirmar" cuando ya hay valores disponibles y quitar el CTA duplicado dentro del modal para mantener una única llamada a la acción.

### Description
- Actualicé el objeto `PES6_PALMARES` en `app.js` con los campeones T22 para las 4 divisiones, las copas y los premios individuales, y ajusté nombres de copas a `Super Final` y `Final Interliga vs S.F.A`.
- Añadí `subtitulo` por premio individual (Balón de Oro y Puskás) y permití que cada tarjeta muestre subtítulo si existe; también cambié los títulos de bloque a: `Campeones por División` (subtítulo `Últimos campeones (Temporada 22)`), `Copas` (subtítulo `Últimos campeones de copas (Temporada 22)`) y `Premios individuales`.
- Modifiqué el render para filtrar entradas vacías y usar `A confirmar` solo como fallback cuando no hay datos reales; los elementos se crean con `createPalmaresCard` y ahora muestran subtítulos cuando aplica.
- Eliminé el CTA duplicado `Unirme a la comunidad` dentro del modal PES6 (`index.html`) y limpié el mapeo en `applyWhatsAppLinks` en `app.js`; añadí estilo `.palmares-subtitle` en `styles.css` para mantener la estética actual.

### Testing
- Ejecuté `node --check app.js` y la comprobación de sintaxis de `app.js` pasó correctamente.
- Verifiqué con búsquedas (`rg`) que los nombres de campeones (`Edug98`, `MartinPalermo`, `H09`, `Cacherinhooo`, `Larrierismo`, `Faquuvilla`, `Pelufo`, `Naxul90`) están presentes en `app.js` y que el CTA duplicado fue removido en `index.html`.
- Intenté validar visualmente con Playwright/servicio local para generar captura, pero la sesión de browser no pudo completar la navegación en este entorno (falló la captura); el cambio no impide el render en runtime según las comprobaciones de DOM y búsquedas automáticas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986a77feae0833284863bbfe8c15551)