### PR TITLE
Agregar pestaña “Historial” en modal PES6 con acordeones dinámicos

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,55 @@
+// === HISTORIAL PES 6 (EDITAR SOLO ESTO) ===
+const PES6_HISTORY = [
+  {
+    season: "Temporada XX",
+    divisions: {
+      div1: "POR DEFINIR",
+      div2: "POR DEFINIR",
+      div3: "POR DEFINIR",
+      div4: "POR DEFINIR"
+    },
+    cups: {
+      interdiv: "POR DEFINIR",
+      superfinal: "POR DEFINIR",
+      interliga: "POR DEFINIR"
+    },
+    awards: {
+      balonOro: "POR DEFINIR",
+      puskas: "POR DEFINIR"
+    }
+  },
+  {
+    season: "Temporada XX",
+    divisions: { div1: "POR DEFINIR", div2: "POR DEFINIR", div3: "POR DEFINIR", div4: "POR DEFINIR" },
+    cups: { interdiv: "POR DEFINIR", superfinal: "POR DEFINIR", interliga: "POR DEFINIR" },
+    awards: { balonOro: "POR DEFINIR", puskas: "POR DEFINIR" }
+  },
+  {
+    season: "Temporada XX",
+    divisions: { div1: "POR DEFINIR", div2: "POR DEFINIR", div3: "POR DEFINIR", div4: "POR DEFINIR" },
+    cups: { interdiv: "POR DEFINIR", superfinal: "POR DEFINIR", interliga: "POR DEFINIR" },
+    awards: { balonOro: "POR DEFINIR", puskas: "POR DEFINIR" }
+  },
+  {
+    season: "Temporada XX",
+    divisions: { div1: "POR DEFINIR", div2: "POR DEFINIR", div3: "POR DEFINIR", div4: "POR DEFINIR" },
+    cups: { interdiv: "POR DEFINIR", superfinal: "POR DEFINIR", interliga: "POR DEFINIR" },
+    awards: { balonOro: "POR DEFINIR", puskas: "POR DEFINIR" }
+  },
+  {
+    season: "Temporada XX",
+    divisions: { div1: "POR DEFINIR", div2: "POR DEFINIR", div3: "POR DEFINIR", div4: "POR DEFINIR" },
+    cups: { interdiv: "POR DEFINIR", superfinal: "POR DEFINIR", interliga: "POR DEFINIR" },
+    awards: { balonOro: "POR DEFINIR", puskas: "POR DEFINIR" }
+  },
+  {
+    season: "Temporada XX",
+    divisions: { div1: "POR DEFINIR", div2: "POR DEFINIR", div3: "POR DEFINIR", div4: "POR DEFINIR" },
+    cups: { interdiv: "POR DEFINIR", superfinal: "POR DEFINIR", interliga: "POR DEFINIR" },
+    awards: { balonOro: "POR DEFINIR", puskas: "POR DEFINIR" }
+  }
+];
+
 // === CONFIGURACIÓN DE CUPOS (EDITAR SOLO ESTO) ===
 const PES6_CUPOS_LIBRES = 8; // 4ta división
 const KOF_CUPOS_LIBRES = 10;  // King of Fighters 2002
@@ -84,6 +136,25 @@ const PES6_PALMARES = {
       subtitulo: "Ganador (Temporada 22)",
       ganadores: ["Naxul90"]
     }
+  ]
+};
+
+
+const PES6_HISTORY_META = {
+  divisions: [
+    { key: "div1", label: "División 1", trophy: "assets/trofeo_div1.png" },
+    { key: "div2", label: "División 2", trophy: "assets/trofeo_div2.png" },
+    { key: "div3", label: "División 3", trophy: "assets/trofeo_div3.png" },
+    { key: "div4", label: "División 4", trophy: "assets/trofeo_div4.png" }
+  ],
+  cups: [
+    { key: "interdiv", label: "Copa Interdivisional", trophy: "assets/trofeo_interdiv.png" },
+    { key: "superfinal", label: "Super Final", trophy: "assets/trofeo_superfinal.png" },
+    { key: "interliga", label: "Final Interliga vs S.F.A", trophy: "assets/trofeo_interliga.png" }
+  ],
+  awards: [
+    { key: "balonOro", label: "Balón de Oro", trophy: "assets/trofeo_balon_oro.png" },
+    { key: "puskas", label: "Premio Puskás", trophy: "assets/trofeo_puskas.png" }
   ]
 };
 
@@ -611,8 +682,150 @@ function renderPalmares() {
   });
 }
 
+function createHistoryRow(itemMeta, value) {
+  const row = document.createElement("div");
+  row.className = "history-row";
+
+  const left = document.createElement("div");
+  left.className = "history-row-left";
+
+  const trophy = document.createElement("img");
+  trophy.className = "history-trophy";
+  trophy.src = itemMeta.trophy;
+  trophy.alt = `Trofeo ${itemMeta.label}`;
+  trophy.loading = "lazy";
+
+  const label = document.createElement("span");
+  label.className = "history-label";
+  label.textContent = itemMeta.label;
+
+  left.append(trophy, label);
+
+  const winner = document.createElement("div");
+  winner.className = "history-value";
+  const safeValue = value && value.trim() !== "" ? value : "POR DEFINIR";
+  const isPending = safeValue.toUpperCase() === "POR DEFINIR";
+  winner.textContent = safeValue;
+
+  if (isPending) {
+    winner.classList.add("is-pending");
+    const badge = document.createElement("span");
+    badge.className = "history-pending-badge";
+    badge.textContent = "Pendiente";
+    winner.appendChild(badge);
+  }
+
+  row.append(left, winner);
+  return row;
+}
+
+function createHistorySection(title, itemsMeta, values = {}) {
+  const section = document.createElement("section");
+  section.className = "history-section";
+
+  const heading = document.createElement("h4");
+  heading.textContent = title;
+  section.appendChild(heading);
+
+  itemsMeta.forEach((itemMeta) => {
+    section.appendChild(createHistoryRow(itemMeta, values[itemMeta.key]));
+  });
+
+  return section;
+}
+
+function animateHistoryPanel(panel, expand) {
+  const isExpanded = panel.dataset.expanded === "true";
+  if (isExpanded === expand) return;
+
+  panel.dataset.expanded = String(expand);
+
+  if (expand) {
+    panel.hidden = false;
+    panel.style.maxHeight = "0px";
+
+    requestAnimationFrame(() => {
+      panel.style.maxHeight = `${panel.scrollHeight}px`;
+    });
+
+    const finishExpand = () => {
+      if (panel.dataset.expanded === "true") {
+        panel.style.maxHeight = "none";
+      }
+      panel.removeEventListener("transitionend", finishExpand);
+    };
+
+    panel.addEventListener("transitionend", finishExpand);
+    return;
+  }
+
+  const currentHeight = panel.scrollHeight;
+  panel.style.maxHeight = `${currentHeight}px`;
+
+  requestAnimationFrame(() => {
+    panel.style.maxHeight = "0px";
+  });
+
+  const finishCollapse = () => {
+    if (panel.dataset.expanded === "false") {
+      panel.hidden = true;
+    }
+    panel.removeEventListener("transitionend", finishCollapse);
+  };
+
+  panel.addEventListener("transitionend", finishCollapse);
+}
+
+function createHistoryAccordionItem(seasonData, index) {
+  const item = document.createElement("article");
+  item.className = "history-accordion-item";
+
+  const trigger = document.createElement("button");
+  trigger.type = "button";
+  trigger.className = "history-accordion-trigger";
+  trigger.setAttribute("aria-expanded", "false");
+  trigger.setAttribute("aria-controls", `pes6-history-panel-${index}`);
+  trigger.innerHTML = `<span>${seasonData.season}</span><span class="history-chevron" aria-hidden="true">⌄</span>`;
+
+  const panel = document.createElement("div");
+  panel.className = "history-accordion-panel";
+  panel.id = `pes6-history-panel-${index}`;
+  panel.hidden = true;
+  panel.dataset.expanded = "false";
+
+  panel.append(
+    createHistorySection("Campeones por División", PES6_HISTORY_META.divisions, seasonData.divisions),
+    createHistorySection("Copas", PES6_HISTORY_META.cups, seasonData.cups),
+    createHistorySection("Premios Individuales", PES6_HISTORY_META.awards, seasonData.awards)
+  );
+
+  trigger.addEventListener("click", () => {
+    const isOpen = trigger.getAttribute("aria-expanded") === "true";
+    const nextOpen = !isOpen;
+
+    trigger.setAttribute("aria-expanded", String(nextOpen));
+    item.classList.toggle("is-open", nextOpen);
+    animateHistoryPanel(panel, nextOpen);
+  });
+
+  item.append(trigger, panel);
+  return item;
+}
+
+function renderPes6History() {
+  const container = document.getElementById("pes6-history");
+  if (!container) return;
+
+  container.replaceChildren();
+
+  PES6_HISTORY.forEach((seasonData, index) => {
+    container.appendChild(createHistoryAccordionItem(seasonData, index));
+  });
+}
+
 setupTabs();
 renderPalmares();
+renderPes6History();
 applyKofLeagueContent();
 applyWhatsAppLinks();
 updateSeasonStatus();

--- a/index.html
+++ b/index.html
@@ -149,6 +149,7 @@
         <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-sistema" id="pes6-tab-btn-sistema" data-tab="pes6-tab-sistema">Sistema de liga</button>
         <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-temporadas" id="pes6-tab-btn-temporadas" data-tab="pes6-tab-temporadas">Temporadas</button>
         <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-palmares" id="pes6-tab-btn-palmares" data-tab="pes6-tab-palmares">Palmarés / Campeones</button>
+        <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-history" id="pes6-tab-btn-history" data-tab="pes6-tab-history">Historial</button>
       </div>
 
       <div class="tab-content">
@@ -225,6 +226,10 @@ UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES
 
         <section class="tab-panel" role="tabpanel" id="pes6-tab-palmares" aria-labelledby="pes6-tab-btn-palmares" hidden>
           <div id="pes6-palmares-content" class="palmares-layout"></div>
+        </section>
+
+        <section class="tab-panel" role="tabpanel" id="pes6-tab-history" aria-labelledby="pes6-tab-btn-history" hidden>
+          <div id="pes6-history" class="history-layout"></div>
         </section>
       </div>
 

--- a/styles.css
+++ b/styles.css
@@ -596,6 +596,138 @@ summary:focus-visible,
   padding-left: 1rem;
 }
 
+.history-layout {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.history-accordion-item {
+  border: 1px solid rgba(110, 177, 255, 0.35);
+  border-radius: 0.85rem;
+  background: rgba(8, 24, 49, 0.72);
+  box-shadow: inset 0 0 0 1px rgba(70, 131, 211, 0.2);
+  overflow: clip;
+}
+
+.history-accordion-trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  border: 0;
+  color: var(--text-main);
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 700;
+  text-align: left;
+  padding: 0.9rem 1rem;
+  background: linear-gradient(180deg, rgba(18, 45, 90, 0.65), rgba(8, 22, 48, 0.7));
+  cursor: pointer;
+  transition: background-color 200ms ease;
+}
+
+.history-accordion-trigger:hover,
+.history-accordion-trigger:focus-visible {
+  background: linear-gradient(180deg, rgba(28, 61, 117, 0.68), rgba(11, 30, 62, 0.82));
+}
+
+.history-accordion-trigger:focus-visible {
+  outline: 2px solid rgba(148, 212, 255, 0.9);
+  outline-offset: -2px;
+}
+
+.history-chevron {
+  font-size: 1.15rem;
+  color: #b9dcff;
+  transition: transform 240ms ease;
+}
+
+.history-accordion-item.is-open .history-chevron {
+  transform: rotate(180deg);
+}
+
+.history-accordion-panel {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height 320ms ease, opacity 220ms ease;
+}
+
+.history-accordion-item.is-open .history-accordion-panel {
+  opacity: 1;
+}
+
+.history-section {
+  padding: 0.35rem 0.8rem 0.85rem;
+}
+
+.history-section + .history-section {
+  border-top: 1px solid rgba(106, 178, 255, 0.2);
+}
+
+.history-section h4 {
+  margin: 0.35rem 0 0.7rem;
+  font-size: 0.9rem;
+  color: #d8ecff;
+}
+
+.history-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.55rem 0.85rem;
+  padding: 0.45rem 0;
+}
+
+.history-row + .history-row {
+  border-top: 1px dashed rgba(110, 177, 255, 0.2);
+}
+
+.history-row-left {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-width: min(220px, 100%);
+}
+
+.history-trophy {
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+  filter: drop-shadow(0 0 0.35rem rgba(101, 184, 255, 0.45));
+}
+
+.history-label {
+  font-weight: 600;
+}
+
+.history-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 700;
+  color: #eef6ff;
+  word-break: break-word;
+}
+
+.history-value.is-pending {
+  opacity: 0.62;
+}
+
+.history-pending-badge {
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.16rem 0.42rem;
+  border-radius: 999px;
+  border: 1px solid rgba(160, 198, 235, 0.45);
+  background: rgba(116, 148, 187, 0.24);
+  color: #d5e9ff;
+}
+
 @keyframes tab-panel-in {
   from {
     opacity: 0;
@@ -764,6 +896,11 @@ summary:focus-visible,
 
   .league-modal {
     padding: 1.85rem;
+  }
+
+  .history-trophy {
+    width: 36px;
+    height: 36px;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Añadir una pestaña «Historial» en el modal de `PES 6 – Infinity Patch` para mostrar temporadas pasadas sin hardcodear HTML. 
- Permitir que toda la información del historial provenga exclusivamente de un bloque editable en `app.js` para que el usuario solo edite datos. 
- Mantener la estética actual (azul/glow), comportamiento de las pestañas existentes y prioridad mobile-first con animaciones suaves al expandir.

### Description
- Agregada la pestaña `Historial` y el contenedor dinámico `#pes6-history` en `index.html` para render en JS. 
- Añadido en `app.js` el bloque obligatorio editable `PES6_HISTORY` (6 temporadas base) y metadatos `PES6_HISTORY_META` para mapear divisiones, copas y premios a trofeos existentes. 
- Implementadas funciones de render y UI: `renderPes6History`, `createHistoryAccordionItem`, `createHistorySection`, `createHistoryRow` y `animateHistoryPanel` que generan acordeones por temporada, muestran 3 secciones (Divisiones, Copas, Premios) y marcan `POR DEFINIR` con opacidad/badge "Pendiente". 
- Añadidos estilos en `styles.css` (clases `.history-*`) mobile-first, trofeos 32–36px, layout full-width y transiciones para expand/collapse, utilizando los PNG ya presentes en `assets/`.

### Testing
- Ejecutado `node --check app.js` para validación sintáctica y pasó correctamente. 
- Verificado con `rg` la presencia de referencias (`pes6-tab-history`, `pes6-history`, `history-`) en `index.html`, `app.js` y `styles.css`. 
- Levantado servidor local y corrido un script Playwright que abrió el modal PES6, seleccionó la pestaña `Historial`, expandió un acordeón y tomó una captura de flujo móvil (`artifacts/pes6-history-mobile.png`), validando el render y la animación; la comprobación automatizada completó con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698797db014c83329ae2a6aba7a8682b)