### PR TITLE
Ajusta el ranking PES6 para contar solo títulos de prestigio

### DIFF
--- a/app.js
+++ b/app.js
@@ -154,9 +154,15 @@ const PES6_TITLE_META = {
     interliga: { type: "Copa", title: "Final Interliga vs S.F.A" }
   },
   awards: {
-    balonOro: { type: "Premio", title: "Balón de Oro (últimas 3 temporadas)" },
+    balonOro: { type: "Premio", title: "Balón de Oro" },
     puskas: { type: "Premio", title: "Premio Puskás" }
   }
+};
+
+const PES6_COUNTED_TITLES = {
+  divisions: ["div1"],
+  cups: ["interdiv", "superfinal", "interliga"],
+  awards: ["balonOro", "puskas"]
 };
 
 const PES6_HISTORY_META = {
@@ -721,11 +727,16 @@ function buildPes6TitleMap(history) {
   const titleMap = {};
 
   history.forEach((seasonData) => {
-    ["divisions", "cups", "awards"].forEach((groupKey) => {
+    Object.entries(PES6_COUNTED_TITLES).forEach(([groupKey, allowedKeys]) => {
       const groupData = seasonData[groupKey] || {};
       const groupMeta = PES6_TITLE_META[groupKey];
 
-      Object.entries(groupMeta).forEach(([key, meta]) => {
+      allowedKeys.forEach((key) => {
+        const meta = groupMeta[key];
+        if (!meta) {
+          return;
+        }
+
         const winner = groupData[key];
 
         if (!isValidTitleWinner(winner)) {


### PR DESCRIPTION
### Motivation
- Implementar un ranking automático en la pestaña “Ranking de Títulos” que cuente únicamente los títulos solicitados (División 1, copas interdiv/superfinal/interliga y premios balonOro/puskas) y excluya Div2–Div4.
- Mantener la estética y el comportamiento existente: mobile-first, detalle expandible por jugador y filtrado de valores pendientes como `POR DEFINIR`.

### Description
- Actualicé `PES6_TITLE_META` para normalizar la etiqueta de `balonOro` a `"Balón de Oro"` para consistencia en el detalle. (`app.js`)
- Agregué `PES6_COUNTED_TITLES` que declara explícitamente los campos que se deben contar: `divisions.div1`, `cups.interdiv|superfinal|interliga`, `awards.balonOro|puskas`. (`app.js`)
- Modifiqué `buildPes6TitleMap()` para iterar solo sobre las entradas de `PES6_COUNTED_TITLES`, de modo que tanto el total del ranking como el listado del panel expandible usan el mismo filtro y no muestran Div2–Div4. (`app.js`)
- Se preserva el filtrado existente de valores inválidos/pendientes mediante `isValidTitleWinner()` y el ordenamiento por total descendente con desempate alfabético. (`app.js`)

### Testing
- Ejecuté `node --check app.js` y no reportó errores, por lo que la sintaxis es válida. (éxito)
- Levanté un servidor local con `python3 -m http.server 4173 --bind 0.0.0.0` y verifiqué visualmente el modal PES6 en mobile usando un script de Playwright que abrió el modal, seleccionó la pestaña Historial / Ranking de Títulos y expandió un detalle; la captura fue generada. (éxito)
- El cambio quedó registrado en `app.js` y se confirmó con una prueba de interfaz automatizada que generó la captura `pes6-ranking-mobile.png`. (éxito)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987ab1ba5c48332900118c8fed2c69f)