### PR TITLE
Separar Ranking de Títulos del Historial y mostrar desglose por jugador

### DIFF
--- a/app.js
+++ b/app.js
@@ -745,10 +745,19 @@ function buildPes6TitleMap(history) {
 
         const player = winner.trim();
         if (!titleMap[player]) {
-          titleMap[player] = { total: 0, items: [] };
+          titleMap[player] = {
+            total: 0,
+            counts: { primera: 0, copas: 0, individuales: 0 },
+            items: []
+          };
         }
 
         titleMap[player].total += 1;
+
+        if (groupKey === "divisions") titleMap[player].counts.primera += 1;
+        if (groupKey === "cups") titleMap[player].counts.copas += 1;
+        if (groupKey === "awards") titleMap[player].counts.individuales += 1;
+
         titleMap[player].items.push({
           season: seasonData.season,
           type: meta.type,
@@ -840,7 +849,7 @@ function createPes6RankingItem(player, playerData, index) {
   toggle.className = "pes6-ranking-toggle";
   toggle.setAttribute("aria-expanded", "false");
   toggle.setAttribute("aria-controls", `pes6-ranking-panel-${index}`);
-  toggle.innerHTML = '<span>Ver títulos</span><span class="pes6-ranking-chevron" aria-hidden="true">⌄</span>';
+  toggle.innerHTML = '<span>Ver detalle</span><span class="pes6-ranking-chevron" aria-hidden="true">⌄</span>';
 
   header.append(position, name, stats, toggle);
 
@@ -850,16 +859,16 @@ function createPes6RankingItem(player, playerData, index) {
   panel.hidden = true;
   panel.dataset.expanded = "false";
 
-  const list = document.createElement("ul");
-  list.className = "pes6-ranking-list";
+  const breakdown = document.createElement("p");
+  breakdown.className = "pes6-ranking-breakdown";
+  breakdown.textContent = `Primera División: ${playerData.counts.primera} | Copas: ${playerData.counts.copas} | Individuales: ${playerData.counts.individuales}`;
 
-  playerData.items.forEach((item) => {
-    const li = document.createElement("li");
-    li.textContent = `${item.season} — ${item.type} — ${item.title}`;
-    list.appendChild(li);
-  });
+  const titles = playerData.items.map((item) => `${item.season} ${item.title}`);
+  const titlesLine = document.createElement("p");
+  titlesLine.className = "pes6-ranking-titles";
+  titlesLine.textContent = `Títulos: ${titles.join(" | ")}`;
 
-  panel.appendChild(list);
+  panel.append(breakdown, titlesLine);
 
   toggle.addEventListener("click", () => {
     const isOpen = toggle.getAttribute("aria-expanded") === "true";
@@ -885,6 +894,10 @@ function renderPes6Ranking() {
   container.replaceChildren();
 
   if (!ranking.length) {
+    const empty = document.createElement("p");
+    empty.className = "pes6-ranking-empty";
+    empty.textContent = "Sin datos";
+    container.appendChild(empty);
     return;
   }
 
@@ -892,11 +905,11 @@ function renderPes6Ranking() {
   wrapper.className = "pes6-ranking";
 
   const heading = document.createElement("h3");
-  heading.textContent = "Ranking de títulos";
+  heading.textContent = "RANKING DE TÍTULOS";
 
   const subtitle = document.createElement("p");
   subtitle.className = "pes6-ranking-subtitle";
-  subtitle.textContent = "Conteo total histórico por cantidad de títulos.";
+  subtitle.textContent = "Solo cuenta Primera División, Copas y Premios individuales.";
 
   const list = document.createElement("div");
   list.className = "pes6-ranking-list-wrap";

--- a/index.html
+++ b/index.html
@@ -150,6 +150,7 @@
         <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-temporadas" id="pes6-tab-btn-temporadas" data-tab="pes6-tab-temporadas">Temporadas</button>
         <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-palmares" id="pes6-tab-btn-palmares" data-tab="pes6-tab-palmares">Palmarés / Campeones</button>
         <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-history" id="pes6-tab-btn-history" data-tab="pes6-tab-history">Historial</button>
+        <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-ranking" id="pes6-tab-btn-ranking" data-tab="pes6-tab-ranking">Ranking de títulos</button>
       </div>
 
       <div class="tab-content">
@@ -229,8 +230,11 @@ UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES
         </section>
 
         <section class="tab-panel" role="tabpanel" id="pes6-tab-history" aria-labelledby="pes6-tab-btn-history" hidden>
-          <div id="pes6-ranking"></div>
           <div id="pes6-history" class="history-layout"></div>
+        </section>
+
+        <section class="tab-panel" role="tabpanel" id="pes6-tab-ranking" aria-labelledby="pes6-tab-btn-ranking" hidden>
+          <div id="pes6-ranking"></div>
         </section>
       </div>
 

--- a/styles.css
+++ b/styles.css
@@ -713,6 +713,33 @@ summary:focus-visible,
   opacity: 1;
 }
 
+
+.pes6-ranking-breakdown,
+.pes6-ranking-titles {
+  margin: 0 0.75rem 0.75rem;
+  padding: 0.7rem 0.8rem;
+  border-radius: 0.7rem;
+  border: 1px solid rgba(126, 193, 255, 0.26);
+  background: rgba(9, 24, 52, 0.78);
+  color: #e6f3ff;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.pes6-ranking-titles {
+  margin-top: -0.35rem;
+}
+
+.pes6-ranking-empty {
+  margin: 0;
+  padding: 1rem;
+  border-radius: 0.8rem;
+  border: 1px solid rgba(120, 188, 255, 0.28);
+  background: rgba(8, 24, 49, 0.72);
+  color: var(--text-soft);
+}
+
+
 .pes6-ranking-list {
   margin: 0 0.75rem 0.75rem;
   padding: 0.7rem 0.8rem 0.7rem 1.35rem;


### PR DESCRIPTION
### Motivation
- El ranking de títulos estaba embebido dentro del panel `Historial` y debe vivir en una sección independiente para mantener `Historial` centrado solo en temporadas/paneles.
- El ranking debe computarse automáticamente desde los datos existentes y mostrar no solo totales sino también el desglose por tipo y la lista de títulos por jugador.

### Description
- Moví el bloque de ranking fuera de la pestaña `Historial` y creé una nueva pestaña/panel `Ranking de títulos` (`pes6-tab-ranking`) con su propio contenedor `#pes6-ranking` en `index.html`.
- Añadí un botón en la barra de pestañas del modal PES6 para acceder a la nueva sección sin alterar el resto del layout.
- Modifiqué `buildPes6TitleMap` en `app.js` para acumular sólo los títulos permitidos según la regla (Primera División `div1`, Copas y Premios individuales), y añadí contadores por categoría (`primera`, `copas`, `individuales`) por jugador.
- Actualicé el render del ranking en `app.js` para ordenar por total descendente, mostrar total + etiqueta, mostrar el desglose por categoría y una línea `Títulos: [...]` con los nombres de los títulos por temporada, y para no romper la UI mostrar `Sin datos` cuando corresponda.
- Añadí estilos mínimos en `styles.css` para el detalle del desglose y el estado vacío, manteniendo el diseño existente.
- Archivos modificados: `index.html`, `app.js`, `styles.css`.

### Testing
- Ejecuté la verificación de sintaxis JavaScript con `node --check app.js` y pasó correctamente.
- Intenté una prueba visual automatizada (Playwright) para abrir el modal, cambiar a la pestaña `Ranking de títulos` y capturar una captura, pero el entorno devolvió `ERR_EMPTY_RESPONSE` al servir la página, por lo que la captura no se generó; el resto de la lógica fue inspeccionada localmente en el código y con `node --check`.
- No se modificaron otras funciones de `Historial` y las llamadas a `renderPes6Ranking()` / `renderPes6History()` permanecen para ejecución normal en carga de la página.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987c2a540d88332a9944a15a2474af9)