### PR TITLE
Excluir "NO SE DISPUTA" y mostrar Top 5 por defecto con toggle (Ranking de títulos)

### DIFF
--- a/app.js
+++ b/app.js
@@ -222,6 +222,7 @@ const kofContentBindings = {
 
 let activeModal = null;
 let lastFocusedElement = null;
+let showAllTitlesRanking = false;
 
 // Asignación centralizada de links editables.
 
@@ -714,7 +715,7 @@ function isValidTitleWinner(value) {
   const normalized = value.trim();
   if (!normalized) return false;
 
-  const invalidValues = ["POR DEFINIR", "NO EXISTIA", "NO SE DISPUTO"];
+  const invalidValues = ["POR DEFINIR", "NO EXISTIA", "NO SE DISPUTO", "NO SE DISPUTA"];
   return !invalidValues.includes(normalized.toUpperCase());
 }
 
@@ -914,11 +915,25 @@ function renderPes6Ranking() {
   const list = document.createElement("div");
   list.className = "pes6-ranking-list-wrap";
 
-  ranking.forEach(([player, data], index) => {
+  const visibleRanking = showAllTitlesRanking ? ranking : ranking.slice(0, 5);
+
+  visibleRanking.forEach(([player, data], index) => {
     list.appendChild(createPes6RankingItem(player, data, index));
   });
 
-  wrapper.append(heading, subtitle, list);
+  const listToggle = document.createElement("button");
+  listToggle.type = "button";
+  listToggle.className = "pes6-ranking-toggle";
+  listToggle.textContent = showAllTitlesRanking ? "Ver top 5" : "Ver todos";
+  listToggle.style.margin = "0.85rem auto 0";
+  listToggle.style.display = "flex";
+
+  listToggle.addEventListener("click", () => {
+    showAllTitlesRanking = !showAllTitlesRanking;
+    renderPes6Ranking();
+  });
+
+  wrapper.append(heading, subtitle, list, listToggle);
   container.appendChild(wrapper);
 }
 


### PR DESCRIPTION
### Motivation
- Evitar que la cadena “NO SE DISPUTA” aparezca o sume títulos en el ranking.  
- Mostrar por defecto solo el TOP 5 al entrar en "Ranking de títulos" y permitir al usuario ver el listado completo mediante un botón sin cambiar la estética.  
- Mantener el orden actual por cantidad de títulos y el diseño existente, incluyendo funcionamiento en mobile.  

### Description
- Se actualizó la validación de ganadores en `isValidTitleWinner` para excluir también `"NO SE DISPUTA"` de la contabilización y renderizado.  
- Se agregó un estado booleano global `showAllTitlesRanking` para controlar la vista (por defecto `false`).  
- El render de la sección `renderPes6Ranking()` ahora muestra `ranking.slice(0,5)` cuando `showAllTitlesRanking` es `false` y el ranking completo cuando es `true`.  
- Se añadió un botón dentro de la sección de ranking (reutiliza la clase `pes6-ranking-toggle`) que alterna el estado y cambia su texto entre `"Ver todos"` y `"Ver top 5"`, y dispara un re-render manteniendo estilos y comportamiento responsive; el archivo modificado es `app.js`.  

### Testing
- Ejecutado `node --check app.js` para validar la sintaxis de `app.js` (resultado: éxito).  
- Levantado servidor local con `python3 -m http.server 4173 --directory /workspace/sudaka-league` y se realizó una prueba visual automatizada con Playwright que abrió el modal PES6 → pestaña Ranking de títulos, tomó captura del Top 5 por defecto y luego pulsó el botón `Ver todos` y tomó la captura del ranking completo (resultado: éxito; generadas capturas).  
- No se modificaron estilos globales ni otras secciones del sitio y el orden del ranking sigue siendo por `total` descendente con el criterio de desempate previo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d5057d7c833297e40bb9860c4d93)