### PR TITLE
Add CountAPI-based visitor counter to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,6 +337,48 @@ UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES
 
   <button id="back-to-top" class="btn btn-primary back-to-top" type="button" aria-label="Volver arriba">Volver arriba ↑</button>
 
+  <div id="visitor-counter" style="text-align:center; padding:16px 12px 28px; font-size:0.95rem; opacity:0.9;">
+    Visitantes: <strong id="visitor-count">Cargando…</strong>
+  </div>
+
   <script src="app.js"></script>
+  <script>
+    (function () {
+      var namespace = "sudaka-league";
+      var key = "home";
+      var storageKey = "sudaka-league-home-visited";
+      var counterEl = document.getElementById("visitor-count");
+
+      function setCount(value) {
+        if (counterEl) {
+          counterEl.textContent = value;
+        }
+      }
+
+      function fetchCount(url) {
+        return fetch(url).then(function (response) {
+          if (!response.ok) throw new Error("CountAPI request failed");
+          return response.json();
+        });
+      }
+
+      var hasVisited = localStorage.getItem(storageKey) === "1";
+      var endpoint = hasVisited
+        ? "https://api.countapi.xyz/get/" + namespace + "/" + key
+        : "https://api.countapi.xyz/hit/" + namespace + "/" + key;
+
+      fetchCount(endpoint)
+        .then(function (data) {
+          if (!hasVisited) {
+            localStorage.setItem(storageKey, "1");
+          }
+          setCount(typeof data.value === "number" ? data.value : "N/D");
+        })
+        .catch(function () {
+          setCount("No disponible");
+        });
+    })();
+  </script>
+
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a simple, static visitor counter that works on GitHub Pages without a backend by using CountAPI and browser storage.
- Preserve all existing site content and layout while adding a visible visitors metric at the bottom of the page.

### Description
- Added a `#visitor-counter` block to the bottom of `index.html` that displays the visitor count and a `strong` element with id `visitor-count` for updates.
- Included inline JavaScript that uses CountAPI with namespace `sudaka-league` and key `home`, incrementing the count only on the first visit per browser by storing a flag in `localStorage`.
- The script requests `hit` on first visit and `get` on subsequent visits, updates the displayed value, and shows a fallback message on error.
- Kept the existing HTML structure, assets, and `app.js` include intact.

### Testing
- Served the site with `python -m http.server 4173` and captured a full-page browser screenshot via Playwright, which succeeded and confirmed the counter is visible.
- Verified the modified file is staged and committed to the repo via automated `git` commands which completed successfully.
- Attempted HTML linting with `xmllint --html --noout index.html`, which failed because `xmllint` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698900e40e588332a766aacf472cf8e1)