### PR TITLE
PES6: contador dinámico de fin de temporada (target local 2026-02-22 23:59)

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,7 +56,7 @@ const KOF_CUPOS_LIBRES = 10;  // King of Fighters 2002
 
 const WHATSAPP_COMUNIDAD = "https://chat.whatsapp.com/DvRyA2bxAC67x0ulPQYvCa?mode=gi_t";
 const PES6_SEASON_NAME = "Temporada 24";
-const PES6_SEASON_END = "2026-02-07T23:59:00-03:00";
+const PES6_TARGET_LOCAL = new Date(2026, 1, 22, 23, 59, 0, 0);
 const KOF_LEAGUE = {
   nombre: "King of Fighters 2002 – Fightcade",
   nombreCorto: "KOF 2002",
@@ -190,7 +190,7 @@ const closeButtons = [...document.querySelectorAll(".close-btn")];
 const copyButtons = [...document.querySelectorAll(".copy-btn")];
 const backToTopButton = document.getElementById("back-to-top");
 const pes6Status = document.getElementById("pes6Status");
-const pes6Countdown = document.getElementById("pes6Countdown");
+const pes6Remaining = document.getElementById("pes6-remaining");
 const pes6SeasonName = document.getElementById("pes6SeasonName");
 const sfStatus = document.getElementById("sfStatus");
 const sfSeasonName = document.getElementById("sfSeasonName");
@@ -230,33 +230,34 @@ function setPes6EndedState() {
   pes6Status.textContent = "FINALIZADA";
   pes6Status.classList.remove("season-badge-active");
   pes6Status.classList.add("season-badge-ended");
-  pes6Countdown.textContent = "Temporada finalizada";
+  updatePes6Remaining();
 }
 
-function getCountdownText() {
-  const msRemaining = new Date(PES6_SEASON_END).getTime() - Date.now();
+function updatePes6Remaining() {
+  const el = document.getElementById("pes6-remaining");
 
-  if (msRemaining <= 0) {
-    return null;
+  if (!el) return;
+
+  const now = new Date();
+  const ms = PES6_TARGET_LOCAL - now;
+
+  if (ms <= 0) {
+    el.textContent = "Finaliza en: 0 días";
+    return;
   }
 
-  const totalMinutes = Math.floor(msRemaining / (1000 * 60));
-  const totalHours = Math.floor(msRemaining / (1000 * 60 * 60));
-  const totalDays = Math.floor(msRemaining / (1000 * 60 * 60 * 24));
-
-  if (msRemaining >= 1000 * 60 * 60 * 48) {
-    return `${totalDays} días`;
+  if (ms < 24 * 60 * 60 * 1000) {
+    const hours = Math.max(0, Math.ceil(ms / (60 * 60 * 1000)));
+    el.textContent = `Finaliza en: ${hours} horas`;
+    return;
   }
 
-  if (msRemaining >= 1000 * 60 * 60 * 2) {
-    return `${totalHours} horas`;
-  }
-
-  return `${Math.max(totalMinutes, 0)} min`;
+  const days = Math.max(0, Math.ceil(ms / (24 * 60 * 60 * 1000)));
+  el.textContent = `Finaliza en: ${days} días`;
 }
 
 function updateSeasonStatus() {
-  if (!pes6Status || !pes6Countdown || !pes6SeasonName || !sfStatus || !sfSeasonName || !sfSeasonNote) {
+  if (!pes6Status || !pes6Remaining || !pes6SeasonName || !sfStatus || !sfSeasonName || !sfSeasonNote) {
     return;
   }
 
@@ -265,9 +266,9 @@ function updateSeasonStatus() {
   sfStatus.textContent = KOF_LEAGUE.temporada.estado;
   sfSeasonNote.textContent = KOF_LEAGUE.temporada.nota;
 
-  const countdownText = getCountdownText();
+  const msRemaining = PES6_TARGET_LOCAL - new Date();
 
-  if (!countdownText) {
+  if (msRemaining <= 0) {
     setPes6EndedState();
     return;
   }
@@ -275,7 +276,7 @@ function updateSeasonStatus() {
   pes6Status.textContent = "ACTIVA";
   pes6Status.classList.add("season-badge-active");
   pes6Status.classList.remove("season-badge-ended");
-  pes6Countdown.textContent = countdownText;
+  updatePes6Remaining();
 }
 
 function updateSlotsStatus() {
@@ -1085,5 +1086,7 @@ renderPes6History();
 applyKofLeagueContent();
 applyWhatsAppLinks();
 updateSeasonStatus();
+updatePes6Remaining();
 updateSlotsStatus();
 setInterval(updateSeasonStatus, 30000);
+setInterval(updatePes6Remaining, 60000);

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
             <span id="pes6Status" class="season-badge season-badge-active">ACTIVA</span>
           </div>
           <p id="pes6SeasonName" class="season-title">Temporada 24</p>
-          <p class="season-countdown-label">Finaliza en:22 de febrero 2026 <span id="pes6Countdown">Calculando…</span></p>
+          <p class="season-countdown-label"><span id="pes6-remaining">Calculando…</span></p>
           <div class="season-slots" aria-label="Cupos PES 6">
             <span class="season-slots-label">Cupos:</span>
             <span id="pes6-slots" class="season-slots-value">0 libres</span>


### PR DESCRIPTION
### Motivation

- Actualizar el cartel del card "PES 6 – Infinity Patch" para mostrar un contador dinámico exclusivo que respete la fecha objetivo local `2026-02-22 23:59:00` y las reglas de presentación (días si >=24h, horas si <24h y >0, y `0 días` si ya terminó). 

### Description

- Reemplacé el texto estático de finalización en el card PES6 por un elemento dedicado `#pes6-remaining` en `index.html` para no tocar otros cards.  
- Introduje `PES6_TARGET_LOCAL = new Date(2026, 1, 22, 23, 59, 0, 0)` y la función `updatePes6Remaining()` en `app.js` que calcula `ms` y muestra `Finaliza en: X días`, `Finaliza en: Y horas` o `Finaliza en: 0 días` usando `Math.ceil` + `Math.max(0, ...)`.  
- Reemplacé las referencias al antiguo contador por el nuevo binding (`pes6-remaining`) y adapté `updateSeasonStatus()` para usar el nuevo cálculo manteniendo los badges y clases existentes.  
- Llamo a `updatePes6Remaining()` al cargar y programo su actualización cada minuto con `setInterval(updatePes6Remaining, 60000)` para que el último día se decremente correctamente.

### Testing

- Ejecuté `node --check app.js` y pasó sin errores.  
- Levanté un servidor estático con `python -m http.server 4173` y verifiqué la página cargada automáticamente con un script Playwright que tomó una captura (`pes6-countdown-update.png`) y completó correctamente.  
- Los checks automatizados ejecutados en el flujo (sintaxis JS y captura por Playwright) finalizaron con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a1c0da9d4833289cf1cc43bb2fdfc)