### PR TITLE
Reorder home layout and highlight season status dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,15 +28,6 @@
   </header>
 
   <main>
-    <section class="section panel-section hud-separator" aria-labelledby="que-es-title">
-      <h2 id="que-es-title">¿QUÉ ES SUDAKA LEAGUE?</h2>
-      <p>
-        Sudaka League es una comunidad de juegos retro online llevados a un formato competitivo. No hay horarios fijos:
-        los partidos se juegan cuando coinciden dos jugadores disponibles. La coordinación se realiza por WhatsApp y los
-        resultados cuentan para tablas, ascensos y posiciones.
-      </p>
-    </section>
-
     <section class="section hud-separator season-status" aria-labelledby="season-status-title">
       <h2 id="season-status-title">ESTADO DE TEMPORADA</h2>
       <div class="season-grid">
@@ -135,6 +126,15 @@
         <summary>¿Dónde pido ayuda?</summary>
         <p>En la comunidad de WhatsApp o en tu grupo de liga.</p>
       </details>
+    </section>
+
+    <section class="section panel-section hud-separator about-section" aria-labelledby="que-es-title">
+      <h2 id="que-es-title">¿QUÉ ES SUDAKA LEAGUE?</h2>
+      <p>
+        Sudaka League es una comunidad de juegos retro online llevados a un formato competitivo. No hay horarios fijos:
+        los partidos se juegan cuando coinciden dos jugadores disponibles. La coordinación se realiza por WhatsApp y los
+        resultados cuentan para tablas, ascensos y posiciones.
+      </p>
     </section>
   </main>
 

--- a/styles.css
+++ b/styles.css
@@ -1,12 +1,13 @@
 :root {
-  --bg-main: #030814;
-  --bg-panel: rgba(10, 22, 46, 0.82);
-  --bg-elevated: #0c1b39;
-  --text-main: #e8f1ff;
-  --text-soft: #b8c6ea;
-  --line: rgba(84, 164, 255, 0.5);
-  --line-strong: rgba(99, 184, 255, 0.9);
-  --glow: 0 0 0.7rem rgba(89, 173, 255, 0.45);
+  /* Variables unificadas: se conserva la paleta retro arcade final. */
+  --bg-main: #04030b;
+  --bg-panel: rgba(12, 10, 24, 0.86);
+  --bg-elevated: #17122b;
+  --text-main: #eef7ff;
+  --text-soft: #b5b0d1;
+  --line: rgba(43, 214, 255, 0.48);
+  --line-strong: rgba(124, 77, 255, 0.9);
+  --glow: 0 0 0.8rem rgba(43, 214, 255, 0.4);
 }
 
 * {
@@ -213,8 +214,20 @@ summary:focus-visible,
 }
 
 
+.season-status {
+  border: 1px solid rgba(43, 214, 255, 0.45);
+  border-radius: 1rem;
+  padding: clamp(2rem, 4vw, 2.5rem);
+  background: linear-gradient(180deg, rgba(17, 13, 36, 0.92), rgba(10, 8, 22, 0.95));
+  box-shadow: inset 0 0 0 1px rgba(124, 77, 255, 0.2), 0 0 1.2rem rgba(43, 214, 255, 0.2);
+}
+
 .season-status h2 {
   margin-bottom: 1.2rem;
+}
+
+.about-section {
+  padding: clamp(1.6rem, 3.6vw, 2.15rem);
 }
 
 .season-grid {
@@ -1106,17 +1119,6 @@ summary:focus-visible,
    arcade oscura con acentos neón celeste y violeta.
    ========================================================= */
 
-:root {
-  /* Paleta principal retro (fondo oscuro + neón) */
-  --bg-main: #04030b;
-  --bg-panel: rgba(12, 10, 24, 0.86);
-  --bg-elevated: #17122b;
-  --text-main: #eef7ff;
-  --text-soft: #b5b0d1;
-  --line: rgba(43, 214, 255, 0.48);
-  --line-strong: rgba(124, 77, 255, 0.9);
-  --glow: 0 0 0.8rem rgba(43, 214, 255, 0.4);
-}
 
 /* Fondo global con gradientes sutiles + scanlines para textura CRT */
 body {
@@ -1303,6 +1305,10 @@ summary {
   .season-card-header {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .about-section {
+    padding: 1.4rem;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Reordenar la home para seguir el flujo UX solicitado (Hero → Estado de Temporada → Ligas → Sistema de Liga → FAQ → ¿Qué es? → footer) y dar mayor jerarquía visual al estado de temporada.
- Evitar romper JavaScript ni modales manteniendo intactos los IDs y hooks existentes usados por la app.
- Unificar variables duplicadas en `:root` para evitar redefiniciones y mantener la paleta retro-neón consistente.

### Description
- Reordené las secciones dentro de `index.html` para que `season-status` quede primero dentro de `<main>`, seguido por `#ligas`, el trigger del `SISTEMA DE LIGA`, `FAQ` y finalmente la sección informativa `¿QUÉ ES SUDAKA LEAGUE?` con la nueva clase `about-section`.
- Añadí la clase `about-section` a la sección informativa para reducir su peso visual y ajusté su `padding` en desktop y mobile sin cambiar IDs ni data-attributes usados por JS.
- Añadí estilos que destacan `.season-status` como un pequeño “dashboard” (borde, glow, fondo y padding) para darle mayor presencia visual.
- Unifiqué los bloques duplicados de `:root` en un único bloque al inicio de `styles.css` y dejé un comentario aclarando la unificación, preservando la paleta retro arcade final.

### Testing
- Verifiqué la existencia de la definición unificada de `:root` con `rg -n "^:root" styles.css` y la comprobación fue satisfactoria.
- Ejecuté un chequeo automático de presencia de IDs críticos con un script en Python buscando `id="pes6-remaining"`, `id="pes6-slots"`, `id="sf-slots"`, `id="modal-overlay"`, `id="visitor-counter"` y `id="back-to-top"`, y todos están presentes (éxito).
- Inspeccioné el archivo reordenado (`index.html`) para confirmar el nuevo orden de secciones mediante lectura del archivo (éxito).
- Intenté un smoke test visual arrancando `python -m http.server 4173` y capturar una screenshot con Playwright, pero la captura falló con `ERR_EMPTY_RESPONSE` al intentar conectar al servidor (fallido).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a65f2a4d8833285a704f517e8a8c4)