### PR TITLE
Agregar sección “SPONSOR OFICIAL” con tarjeta clickeable y CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,20 @@
       </div>
     </section>
 
+    <section class="section hud-separator" aria-labelledby="sponsor-title">
+      <h2 id="sponsor-title">SPONSOR OFICIAL</h2>
+      <div class="league-grid">
+        <a class="league-card sponsor-card" href="https://www.instagram.com/kelokoclothing.ok?igsh=cHI3ZGV4M2x2M3Zo" target="_blank" rel="noopener noreferrer" aria-label="Ir a la tienda de KELOKO CLOTHING en Instagram">
+          <img class="league-card-banner" src="assets/sponsor.jpg" alt="Banner de KELOKO CLOTHING" />
+          <div class="league-card-content">
+            <h3>KELOKO CLOTHING</h3>
+            <p>Sponsor oficial de la liga.</p>
+            <span class="sponsor-cta">Ir a la tienda</span>
+          </div>
+        </a>
+      </div>
+    </section>
+
     <section class="section hud-separator" aria-labelledby="sistema-liga-title">
       <article
         class="panel-section system-panel-trigger modal-trigger"

--- a/styles.css
+++ b/styles.css
@@ -351,6 +351,33 @@ summary:focus-visible,
   max-width: 60ch;
 }
 
+
+.sponsor-card {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.sponsor-card .league-card-content {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.sponsor-cta {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(147, 98, 255, 0.95);
+  border-radius: 0.95rem;
+  min-height: 44px;
+  padding: 0.65rem 1.1rem;
+  font-size: 0.84rem;
+  font-weight: 800;
+  color: #ecf5ff;
+  background: linear-gradient(180deg, #a587ff 0%, #7d56ff 100%);
+}
+
 .panel-section,
 .faq,
 .about-section {


### PR DESCRIPTION
### Motivation
- Mostrar el sponsor oficial en la página principal como una tarjeta con el mismo estilo visual de las otras `.league-card` sin tocar la lógica JS ni atributos usados por `app.js`.
- Hacer que la tarjeta sea completamente clickeable y abra la tienda de Instagram en una pestaña nueva manteniendo accesibilidad.

### Description
- Se agregó una nueva sección `SPONSOR OFICIAL` inmediatamente después de `#ligas` y antes de la sección `SISTEMA DE LIGA` en `index.html` que contiene un enlace completo (`<a class="league-card sponsor-card" ...>`) apuntando a `https://www.instagram.com/kelokoclothing.ok?igsh=cHI3ZGV4M2x2M3Zo` y con `target="_blank" rel="noopener noreferrer"` y `aria-label` descriptivo.
- La tarjeta muestra `assets/sponsor.jpg` como banner, el título `KELOKO CLOTHING`, el texto `Sponsor oficial de la liga.` y un CTA visible con texto `Ir a la tienda` dentro de la tarjeta.
- Se añadieron reglas CSS mínimas nuevas en `styles.css` para no romper estilos existentes: `.sponsor-card` (ancla que usa el estilo de tarjeta) y `.sponsor-cta` (estilos del CTA tipo botón), manteniendo las clases originales y el comportamiento hover/responsive de `.league-card`.
- Se preservó el versionado anti-cache del CSS en el `<link>` (`styles.css?v=20260209-1`) y no se modificaron IDs o clases utilizadas por la lógica JS (`modal-trigger`, `tab-btn`, `tab-panel`, `copy-btn`, `data-target`, `aria-controls`, etc.).

### Testing
- Busqué y verifiqué la ubicación y las clases relevantes con `rg` para asegurar que la nueva sección quedó entre `#ligas` y `SISTEMA DE LIGA`, y que no se alteraron atributos usados por JS (éxito).
- Levanté un servidor local con `python3 -m http.server 4173` y comprobé que la página carga correctamente (éxito); los logs de servidor muestran un `404` para `assets/sponsor.jpg` porque el asset todavía no existe en el repositorio local (esto es esperado en este entorno y la referencia queda configurada correctamente).
- Generé una captura visual usando Playwright para validar la integración visual de la sección (screenshot generado correctamente).
- Realicé una diff/inspección de los archivos `index.html` y `styles.css` para confirmar que solo se añadieron las líneas necesarias y que no se cambiaron IDs/clases sensibles (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a6fe682b88332b5f9ec56bb091747)