### PR TITLE
Agregar descripción en tarjeta del Sponsor Oficial y cache-busting CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&family=Orbitron:wght@600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css?v=20260209-1" />
+  <link rel="stylesheet" href="styles.css?v=20260209-2" />
 </head>
 <body>
   <div class="bg-effects" aria-hidden="true"></div>
@@ -90,6 +90,11 @@
           <div class="league-card-content">
             <h3>KELOKO CLOTHING</h3>
             <p>Sponsor oficial de la liga.</p>
+            <p class="sponsor-description">Keloko Clothing es la primera marca en sumarse oficialmente a Sudaka League.</p>
+            <p class="sponsor-description">Facu.jey, usuario activo de la liga, acercó su trabajo a la comunidad y, en un gran gesto hacia la misma, decidió premiar a los campeones de Primera División con una remera personalizada de Sudaka League.</p>
+            <p class="sponsor-description">Keloko Clothing se encarga íntegramente de la producción, los envíos y todo lo relacionado al premio, garantizando que cada campeón reciba su reconocimiento de manera directa y sin intermediarios.</p>
+            <p class="sponsor-description">Desde Sudaka League agradecemos profundamente su colaboración y compromiso con la comunidad, y destacamos la importancia de apoyar a los emprendimientos que nacen dentro de la propia liga.</p>
+            <p class="sponsor-description">Incentivamos a Keloko Clothing a continuar desarrollando su negocio, y nos enorgullece contar con su apoyo como sponsor oficial.</p>
             <span class="sponsor-cta">Ir a la tienda</span>
           </div>
         </a>

--- a/styles.css
+++ b/styles.css
@@ -363,6 +363,19 @@ summary:focus-visible,
   gap: 0.9rem;
 }
 
+
+.sponsor-description {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.8;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.sponsor-description + .sponsor-description {
+  margin-top: 0.9rem;
+}
+
 .sponsor-cta {
   display: inline-flex;
   width: fit-content;


### PR DESCRIPTION
### Motivation
- Incluir el texto descriptivo del sponsor dentro de la tarjeta existente para reconocer su aporte y explicar la entrega del premio sin alterar la estructura ni la interacción actual de la tarjeta.

### Description
- Agregué el bloque de texto EXACTO dentro de la tarjeta `league-card sponsor-card` como varias etiquetas `<p class="sponsor-description">` colocadas antes del CTA para mantener el flujo visual y no tocar IDs, `data-target` ni clases usadas por `app.js`.
- Añadí la clase CSS `.sponsor-description` en `styles.css` con color más suave, `line-height` aumentado y separación entre párrafos para mejorar legibilidad y comportamiento responsive en mobile/desktop.
- Actualicé la referencia al CSS en `index.html` a `styles.css?v=20260209-2` para cache busting.

### Testing
- Revisé el diff para asegurar que solo `index.html` y `styles.css` fueron modificados y que la inserción respeta la estructura original (éxito).
- Levanté un servidor local con `python -m http.server` y cargué la página para confirmar que la hoja de estilos nueva se aplica y los assets se sirven correctamente (éxito).
- Generé capturas de pantalla desktop y mobile usando Playwright para validar el espaciado y la legibilidad del bloque dentro de la tarjeta (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a72ffb1cc8332902e5109b7b57c1a)