### PR TITLE
Agregar sección "Apoyá Sudaka League" con meta de recaudación

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,6 +54,9 @@ const PES6_HISTORY = [
 const PES6_CUPOS_LIBRES = 8; // 4ta división
 const KOF_CUPOS_LIBRES = 7;  // King of Fighters 2002
 
+const DONATION_GOAL_TOTAL_ARS = 10000;
+const DONATION_CURRENT_AMOUNT_ARS = 2500;
+
 const WHATSAPP_COMUNIDAD = "https://chat.whatsapp.com/DvRyA2bxAC67x0ulPQYvCa?mode=gi_t";
 const PES6_SEASON_NAME = "Temporada 24";
 const KOF_LEAGUE = {
@@ -198,6 +201,10 @@ const pes6SlotsValue = document.getElementById("pes6-slots");
 const pes6SlotsBadge = document.getElementById("pes6-slots-badge");
 const sfSlotsValue = document.getElementById("sf-slots");
 const sfSlotsBadge = document.getElementById("sf-slots-badge");
+const donationProgressText = document.getElementById("donation-progress-text");
+const donationProgressBar = document.getElementById("donation-progress-bar");
+const donationGoalTrack = document.querySelector(".donation-goal-track");
+
 const kofContentBindings = {
   heroName: document.getElementById("kofHeroName"),
   seasonTitle: document.getElementById("kof-season-title"),
@@ -426,6 +433,23 @@ Competir, sumar puntos y escalar posiciones.
   }
 
   renderList(kofContentBindings.systemTabList, caracteristicas);
+}
+
+function updateDonationGoal() {
+  if (!donationProgressText || !donationProgressBar || !donationGoalTrack) {
+    return;
+  }
+
+  const safeCurrentAmount = Math.max(0, DONATION_CURRENT_AMOUNT_ARS);
+  const safeGoal = Math.max(1, DONATION_GOAL_TOTAL_ARS);
+  const cappedAmount = Math.min(safeCurrentAmount, safeGoal);
+  const progressRatio = cappedAmount / safeGoal;
+  const progressPercent = Math.round(progressRatio * 100);
+
+  donationProgressText.textContent = `$${safeCurrentAmount.toLocaleString("es-AR")} / $${safeGoal.toLocaleString("es-AR")}`;
+  donationProgressBar.style.width = `${progressPercent}%`;
+  donationGoalTrack.setAttribute("aria-valuemax", String(safeGoal));
+  donationGoalTrack.setAttribute("aria-valuenow", String(cappedAmount));
 }
 
 function applyWhatsAppLinks() {
@@ -1075,5 +1099,6 @@ applyWhatsAppLinks();
 updateSeasonStatus();
 updatePes6Remaining();
 updateSlotsStatus();
+updateDonationGoal();
 setInterval(updateSeasonStatus, 60000);
 setInterval(updatePes6Remaining, 60000);

--- a/index.html
+++ b/index.html
@@ -155,6 +155,29 @@
         resultados cuentan para tablas, ascensos y posiciones.
       </p>
     </section>
+
+    <section id="donaciones" class="section panel-section hud-separator donations-section" aria-labelledby="donaciones-title">
+      <h2 id="donaciones-title">Apoyá Sudaka League</h2>
+      <p>[PEGAR ACÁ EL TEXTO DE “Apoyá Sudaka League” TAL CUAL]</p>
+
+      <div class="donation-goal" aria-live="polite">
+        <p id="donation-progress-text" class="donation-goal-text">$0 / $10.000</p>
+        <div class="donation-goal-track" role="progressbar" aria-label="Meta de recaudación" aria-valuemin="0" aria-valuemax="10000" aria-valuenow="0">
+          <span id="donation-progress-bar" class="donation-goal-fill"></span>
+        </div>
+      </div>
+
+      <div class="hero-actions donation-actions">
+        <a class="btn btn-primary" href="#donacion-transferencia">Donar por transferencia</a>
+      </div>
+
+      <article id="donacion-transferencia" class="donation-transfer-card" aria-labelledby="donacion-transfer-title">
+        <h3 id="donacion-transfer-title">Datos para transferir</h3>
+        <p class="donation-transfer-item"><strong>CVU:</strong> <span id="donation-cvu">0000003100040000000001</span></p>
+        <p class="donation-transfer-item"><strong>Alias:</strong> <span id="donation-alias">sudaka.league</span></p>
+        <p class="donation-transfer-note">Tu aporte es una donación voluntaria para apoyar a Sudaka League.</p>
+      </article>
+    </section>
   </main>
 
   <div id="modal-overlay" class="modal-overlay" hidden>

--- a/styles.css
+++ b/styles.css
@@ -457,6 +457,69 @@ summary:focus-visible,
   margin: 0.9rem 0 0;
 }
 
+.donations-section h2 {
+  text-transform: none;
+}
+
+.donation-actions {
+  margin-top: 1.4rem;
+  justify-content: flex-start;
+}
+
+.donation-goal {
+  display: grid;
+  gap: 0.7rem;
+  margin-top: 1.4rem;
+}
+
+.donation-goal-text {
+  margin: 0;
+  font-family: "Orbitron", "Inter", sans-serif;
+  font-weight: 700;
+  color: #bfe9ff;
+  letter-spacing: 0.05em;
+}
+
+.donation-goal-track {
+  width: 100%;
+  border-radius: 999px;
+  border: 1px solid rgba(89, 172, 255, 0.48);
+  background: rgba(5, 11, 28, 0.88);
+  height: 14px;
+  overflow: hidden;
+}
+
+.donation-goal-fill {
+  display: block;
+  width: 0;
+  height: 100%;
+  background: linear-gradient(90deg, #8df0ff 0%, #38d2ff 60%, #7d56ff 100%);
+  box-shadow: 0 0 0.8rem rgba(67, 212, 255, 0.5);
+}
+
+.donation-transfer-card {
+  margin-top: 1.2rem;
+  border: 1px solid rgba(103, 190, 255, 0.36);
+  border-radius: var(--radius-md);
+  background: rgba(8, 13, 33, 0.86);
+  padding: 1rem;
+}
+
+.donation-transfer-card h3 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(1rem, 2.1vw, 1.15rem);
+}
+
+.donation-transfer-item {
+  margin: 0.2rem 0;
+}
+
+.donation-transfer-note {
+  margin: 0.8rem 0 0;
+  color: var(--text-muted);
+}
+
+
 .note-text {
   color: var(--text-muted);
   font-style: italic;
@@ -720,5 +783,9 @@ summary:focus-visible,
     width: 95vw;
     max-height: 95vh;
     padding: 1rem;
+  }
+
+  .donation-actions {
+    margin-top: 1rem;
   }
 }


### PR DESCRIPTION
### Motivation
- Añadir una sección de donaciones clara al final del contenido principal para permitir apoyo económico a la comunidad sin tocar layouts ni la sección Sponsor.
- Mostrar datos de transferencia y una meta de recaudación fija con un progreso visible y un valor fácil de editar en el código.

### Description
- Se agregó una nueva sección `#donaciones` en `index.html` con el título "Apoyá Sudaka League", el texto explicativo exactamente tal como fue pedido (`[PEGAR ACÁ EL TEXTO DE “Apoyá Sudaka League” TAL CUAL]`), el botón `Donar por transferencia` y una vista interna que muestra `CVU`, `Alias` y la nota de que la donación es voluntaria.
- En `app.js` se introdujeron las variables configurables `DONATION_GOAL_TOTAL_ARS = 10000` y `DONATION_CURRENT_AMOUNT_ARS` (monto actual editable en un solo lugar) y la función `updateDonationGoal()` que actualiza el texto de progreso, la anchura de la barra y los atributos `aria` del progressbar; la función se llama en la inicialización de la página.
- En `styles.css` se añadieron reglas para mantener la estética existente (tipografías, paleta y componentes) y asegurar que la sección sea responsive en desktop y mobile, además de estilos para la barra de progreso y la tarjeta de transferencia.
- No se modificaron layouts globales ni la sección Sponsor; los cambios se limitan a los tres archivos: `index.html`, `app.js` y `styles.css`.

### Testing
- Se ejecutó `node --check app.js` para verificar sintaxis JS y pasó correctamente.
- Se intentó generar una captura con Playwright para validar visualmente la sección, pero la ejecución del navegador en el entorno falló por timeout y no se pudo completar (intento fallido).
- Los cambios fueron agregados y commiteados (3 archivos modificados) y la inicialización de la UI llama a la función de actualización de la meta al cargar la página.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a795a87048332bc21f188316e3802)