### PR TITLE
Restaurar estilo visual original (azul/gamer) y adaptar sección de donaciones

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,8 @@
 
     <section id="donaciones" class="section panel-section hud-separator donations-section" aria-labelledby="donaciones-title">
       <h2 id="donaciones-title">Apoyá Sudaka League</h2>
-      <p>[PEGAR ACÁ EL TEXTO DE “Apoyá Sudaka League” TAL CUAL]</p>
+      <p class="donation-intro">💙 Apoyá Sudaka League</p>
+      <p>Sudaka League es un proyecto independiente, s</p>
 
       <div class="donation-goal" aria-live="polite">
         <p id="donation-progress-text" class="donation-goal-text">$0 / $10.000</p>

--- a/styles.css
+++ b/styles.css
@@ -1,18 +1,18 @@
 :root {
-  --bg-main: #06060f;
-  --bg-alt: #0d0b1d;
-  --bg-surface: rgba(18, 16, 40, 0.88);
-  --bg-surface-strong: rgba(12, 12, 29, 0.96);
-  --bg-card: linear-gradient(160deg, rgba(26, 21, 56, 0.92) 0%, rgba(14, 13, 33, 0.96) 55%, rgba(7, 9, 22, 0.98) 100%);
-  --text-main: #f3f7ff;
-  --text-soft: #c2c8e8;
-  --text-muted: #a3abd1;
-  --line: rgba(99, 225, 255, 0.5);
-  --line-strong: rgba(157, 120, 255, 0.95);
-  --radius-lg: 1.3rem;
+  /* Variables globales unificadas para toda la UI (único :root). */
+  --bg-main: #05040d;
+  --bg-surface: rgba(11, 9, 24, 0.86);
+  --bg-surface-strong: rgba(16, 12, 34, 0.95);
+  --bg-card: linear-gradient(180deg, rgba(19, 15, 39, 0.92), rgba(9, 7, 22, 0.96));
+  --text-main: #eef6ff;
+  --text-soft: #b8b2d5;
+  --text-muted: #9e97c4;
+  --line: rgba(78, 188, 255, 0.5);
+  --line-strong: rgba(137, 96, 255, 0.92);
+  --radius-lg: 1.2rem;
   --radius-md: 1rem;
-  --shadow-soft: 0 26px 60px rgba(2, 4, 15, 0.6);
-  --shadow-glow: 0 0 1.2rem rgba(82, 211, 255, 0.26);
+  --shadow-soft: 0 20px 50px rgba(2, 5, 12, 0.58);
+  --shadow-glow: 0 0 1.15rem rgba(43, 214, 255, 0.2);
 }
 
 * { box-sizing: border-box; }
@@ -25,13 +25,13 @@ body {
   overflow-x: hidden;
   font-family: "Inter", system-ui, sans-serif;
   font-size: 16px;
-  line-height: 1.75;
+  line-height: 1.7;
   color: var(--text-main);
   background:
-    radial-gradient(circle at 10% 0%, rgba(81, 237, 255, 0.2), transparent 38%),
-    radial-gradient(circle at 84% 6%, rgba(158, 96, 255, 0.24), transparent 42%),
-    radial-gradient(circle at 56% 86%, rgba(50, 34, 118, 0.38), transparent 46%),
-    linear-gradient(160deg, var(--bg-alt) 0%, #06070f 45%, #050509 100%);
+    radial-gradient(circle at 12% 8%, rgba(43, 214, 255, 0.12), transparent 34%),
+    radial-gradient(circle at 88% 10%, rgba(124, 77, 255, 0.18), transparent 34%),
+    radial-gradient(circle at 50% 100%, rgba(19, 12, 45, 0.74), transparent 55%),
+    linear-gradient(180deg, #090612 0%, #05040d 48%, #030208 100%);
 }
 
 body.no-scroll { overflow: hidden; }
@@ -41,19 +41,18 @@ body.no-scroll { overflow: hidden; }
   inset: 0;
   z-index: -1;
   pointer-events: none;
-  opacity: 0.8;
+  opacity: 0.9;
   mix-blend-mode: screen;
   background-image:
-    linear-gradient(120deg, rgba(255, 255, 255, 0.035), transparent 28%),
-    repeating-linear-gradient(to bottom, rgba(255, 255, 255, 0.02) 0, rgba(255, 255, 255, 0.02) 1px, transparent 3px, transparent 6px),
-    radial-gradient(circle at 18% 26%, rgba(43, 214, 255, 0.18) 0 2px, transparent 2px),
-    radial-gradient(circle at 82% 72%, rgba(154, 122, 255, 0.2) 0 2px, transparent 2px);
+    repeating-linear-gradient(to bottom, rgba(255, 255, 255, 0.03) 0, rgba(255, 255, 255, 0.03) 1px, transparent 2px, transparent 4px),
+    radial-gradient(circle at 20% 20%, rgba(43, 214, 255, 0.18) 0 1px, transparent 1px),
+    radial-gradient(circle at 78% 35%, rgba(124, 77, 255, 0.18) 0 1px, transparent 1px);
 }
 
 .section {
-  width: min(1180px, 92%);
+  width: min(1140px, 92%);
   margin: 0 auto;
-  padding: clamp(4.5rem, 8vw, 6.7rem) 0;
+  padding: clamp(3.25rem, 7vw, 5.8rem) 0;
 }
 
 h1,
@@ -65,7 +64,7 @@ h3,
 .season-badge {
   font-family: "Orbitron", "Inter", sans-serif;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.05em;
 }
 
 h1,
@@ -73,52 +72,52 @@ h2,
 .league-card-content h3,
 .league-modal h2,
 .league-modal h3 {
-  text-shadow: 0 0 0.4rem rgba(99, 225, 255, 0.5), 0 0 1rem rgba(148, 108, 255, 0.28);
+  text-shadow: 0 0 0.3rem rgba(43, 214, 255, 0.55), 0 0 0.95rem rgba(124, 77, 255, 0.25);
 }
 
 h2 {
-  margin: 0 0 2rem;
-  font-size: clamp(1.35rem, 2.9vw, 2rem);
-  line-height: 1.3;
+  margin: 0 0 1.6rem;
+  font-size: clamp(1.25rem, 2.7vw, 1.8rem);
+  line-height: 1.25;
 }
 
 p,
 li {
   margin-top: 0;
-  line-height: 1.75;
+  line-height: 1.7;
 }
 
 .hero {
   text-align: center;
-  padding-top: clamp(5.1rem, 9vw, 8rem);
+  padding-top: clamp(4.4rem, 8vw, 7.3rem);
 }
 
 .hero-kicker {
   margin: 0;
-  color: #a3d4ff;
-  font-size: 0.86rem;
+  color: #96bdff;
+  font-size: 0.82rem;
 }
 
 .hero h1 {
-  margin: 1.5rem 0 1rem;
-  font-size: clamp(2.9rem, 11vw, 6.8rem);
-  line-height: 0.92;
+  margin: 1.2rem 0 0.8rem;
+  font-size: clamp(2.6rem, 12vw, 6.4rem);
+  line-height: 0.96;
 }
 
 .subtitle,
 .hero-copy {
   margin-inline: auto;
   color: var(--text-soft);
-  max-width: 70ch;
+  max-width: 68ch;
 }
 
 .subtitle {
-  margin-bottom: 1.2rem;
+  margin-bottom: 1.1rem;
   font-weight: 700;
 }
 
 .hero-actions {
-  margin-top: 2.4rem;
+  margin-top: 2rem;
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
@@ -127,28 +126,28 @@ li {
 
 .btn {
   border: 1px solid var(--line);
-  border-radius: 0.95rem;
-  min-height: 52px;
-  padding: 0.9rem 1.4rem;
+  border-radius: 0.9rem;
+  min-height: 50px;
+  padding: 0.86rem 1.3rem;
   font-size: 0.86rem;
   font-weight: 800;
   text-decoration: none;
   color: #ecf5ff;
-  background: linear-gradient(180deg, rgba(23, 20, 49, 0.98), rgba(11, 10, 28, 0.96));
-  box-shadow: inset 0 0 0 1px rgba(124, 77, 255, 0.24), 0 0 0.95rem rgba(69, 201, 255, 0.2);
+  background: linear-gradient(180deg, rgba(18, 16, 38, 0.98), rgba(9, 8, 23, 0.96));
+  box-shadow: inset 0 0 0 1px rgba(124, 77, 255, 0.26), 0 0 0.9rem rgba(43, 214, 255, 0.22);
   cursor: pointer;
   transition: transform 180ms ease, box-shadow 220ms ease, filter 200ms ease;
 }
 
 .btn-primary {
-  color: #051720;
-  border-color: #50d8ff;
-  background: linear-gradient(180deg, #8df0ff 0%, #38d2ff 100%);
+  color: #04131a;
+  border-color: #2bd6ff;
+  background: linear-gradient(180deg, #7bf0ff 0%, #2bd6ff 100%);
 }
 
 .btn-secondary {
-  border-color: rgba(147, 98, 255, 0.95);
-  background: linear-gradient(180deg, #a587ff 0%, #7d56ff 100%);
+  border-color: rgba(124, 77, 255, 0.95);
+  background: linear-gradient(180deg, #9d79ff 0%, #7c4dff 100%);
 }
 
 .btn:hover,
@@ -158,8 +157,8 @@ li {
 .league-card:hover,
 .season-card:hover {
   transform: translateY(-2px);
-  filter: brightness(1.06);
-  box-shadow: 0 0 1rem rgba(83, 219, 255, 0.4), 0 0 1.8rem rgba(142, 105, 255, 0.3);
+  filter: brightness(1.05);
+  box-shadow: 0 0 1rem rgba(43, 214, 255, 0.45), 0 0 1.6rem rgba(124, 77, 255, 0.26);
 }
 
 .btn:focus-visible,
@@ -168,7 +167,7 @@ li {
 summary:focus-visible,
 .close-btn:focus-visible,
 .tab-btn:focus-visible {
-  outline: 2px solid #9fd2ff;
+  outline: 2px solid #8ec5ff;
   outline-offset: 2px;
 }
 
@@ -179,12 +178,12 @@ summary:focus-visible,
 .hud-separator::after {
   content: "";
   position: absolute;
-  left: 6%;
-  right: 6%;
+  left: 7%;
+  right: 7%;
   bottom: -0.45rem;
   height: 2px;
-  background: linear-gradient(90deg, transparent, #38d2ff, #8b65ff, transparent);
-  filter: drop-shadow(0 0 0.5rem rgba(67, 214, 255, 0.8));
+  background: linear-gradient(90deg, transparent, #2bd6ff, #7c4dff, transparent);
+  filter: drop-shadow(0 0 0.45rem rgba(43, 214, 255, 0.78));
 }
 
 .panel-section,
@@ -195,65 +194,64 @@ summary:focus-visible,
 .palmares-block,
 .pes6-ranking,
 .season-status {
-  border: 1px solid rgba(86, 223, 255, 0.46);
+  border: 1px solid rgba(43, 214, 255, 0.46);
   border-radius: var(--radius-lg);
   background: var(--bg-card);
-  box-shadow: inset 0 0 0 1px rgba(137, 95, 255, 0.24), var(--shadow-glow), var(--shadow-soft);
+  box-shadow: inset 0 0 0 1px rgba(124, 77, 255, 0.24), var(--shadow-glow), var(--shadow-soft);
 }
 
 .season-status {
-  padding: clamp(3rem, 5.4vw, 3.8rem);
+  padding: clamp(2.4rem, 4.8vw, 3.3rem);
 }
 
 .season-status h2 {
-  margin-bottom: 2.2rem;
+  margin-bottom: 2rem;
 }
 
 .season-grid,
 .league-grid {
   display: grid;
-  gap: clamp(1.6rem, 2.9vw, 2rem);
+  gap: clamp(1.25rem, 2.6vw, 1.6rem);
 }
 
 .season-card {
-  padding: clamp(1.8rem, 3.3vw, 2.4rem);
+  padding: clamp(1.55rem, 3.3vw, 2.2rem);
 }
 
 .season-card-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  gap: 0.95rem;
+  margin-bottom: 0.8rem;
 }
 
 .season-card h3 {
   margin: 0;
-  font-size: clamp(1rem, 2vw, 1.2rem);
+  font-size: clamp(0.96rem, 2vw, 1.15rem);
 }
 
 .season-title,
 .season-note {
-  margin-bottom: 1.2rem;
+  margin-bottom: 1rem;
   color: var(--text-soft);
 }
 
 .season-countdown-label {
-  margin: 1.2rem 0 1.6rem;
+  margin: 1rem 0 1.15rem;
 }
 
 .season-end {
   display: block;
   width: 100%;
-  border: 1px solid rgba(79, 228, 255, 0.62);
+  border: 1px solid rgba(43, 214, 255, 0.55);
   border-radius: 1rem;
-  padding: 1.4rem 1.2rem;
+  padding: 1rem 1.1rem;
   font-family: "Orbitron", "Inter", sans-serif;
-  font-size: clamp(1.25rem, 3.2vw, 1.8rem);
-  text-align: center;
-  letter-spacing: 0.06em;
-  background: linear-gradient(165deg, rgba(16, 52, 76, 0.9), rgba(18, 22, 51, 0.95));
-  box-shadow: inset 0 0 0 1px rgba(128, 221, 255, 0.3), 0 0 1.4rem rgba(67, 212, 255, 0.24);
+  font-size: clamp(1rem, 2.4vw, 1.25rem);
+  letter-spacing: 0.04em;
+  background: linear-gradient(180deg, rgba(8, 36, 56, 0.8), rgba(10, 15, 38, 0.95));
+  box-shadow: inset 0 0 0 1px rgba(114, 199, 255, 0.25), 0 0 1rem rgba(43, 214, 255, 0.18);
 }
 
 .season-badge,
@@ -270,30 +268,27 @@ summary:focus-visible,
 }
 
 .season-badge {
-  padding: 0.36rem 0.75rem;
+  padding: 0.34rem 0.72rem;
 }
 
 .season-badge-active {
-  color: #042530;
-  border-color: #4bdfff;
-  background: linear-gradient(180deg, #95f2ff, #38d2ff);
+  color: #03212b;
+  border-color: #2bd6ff;
+  background: linear-gradient(180deg, #89efff, #2bd6ff);
 }
 
 .season-badge-wait,
 .season-badge-ended {
-  color: #fbf2ff;
-  border-color: rgba(138, 94, 255, 0.9);
-  background: linear-gradient(180deg, #b096ff, #7e57ff);
+  color: #f8eeff;
+  border-color: rgba(124, 77, 255, 0.88);
+  background: linear-gradient(180deg, #a689ff, #7c4dff);
 }
 
 .season-slots {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.7rem;
-  margin-top: 0.6rem;
-  padding-top: 1rem;
-  border-top: 1px solid rgba(88, 168, 255, 0.3);
+  gap: 0.6rem;
   color: var(--text-soft);
 }
 
@@ -306,9 +301,9 @@ summary:focus-visible,
 
 .mini-badge {
   padding: 0.24rem 0.65rem;
-  border-color: rgba(72, 217, 255, 0.38);
-  background: rgba(18, 33, 70, 0.75);
-  color: #dbf3ff;
+  border-color: rgba(43, 214, 255, 0.38);
+  background: rgba(14, 29, 60, 0.75);
+  color: #d6efff;
 }
 
 .mini-badge--open {
@@ -329,72 +324,32 @@ summary:focus-visible,
 .league-card-banner,
 .modal-banner {
   width: 100%;
-  height: clamp(300px, 34vw, 340px);
+  height: clamp(280px, 32vw, 320px);
   display: block;
   object-fit: cover;
   object-position: center;
 }
 
 .league-card-content {
-  padding: 2rem;
+  padding: clamp(1.5rem, 3vw, 2rem);
 }
 
 .league-card-content h3 {
-  margin: 0 0 1rem;
-  font-size: clamp(1.06rem, 2.2vw, 1.3rem);
+  margin: 0 0 0.85rem;
+  font-size: clamp(1rem, 2.2vw, 1.26rem);
 }
 
 .league-card-content p {
   margin: 0;
   color: var(--text-soft);
-  line-height: 1.85;
-  max-width: 60ch;
-}
-
-
-.sponsor-card {
-  display: block;
-  text-decoration: none;
-  color: inherit;
-}
-
-.sponsor-card .league-card-content {
-  display: grid;
-  gap: 0.9rem;
-}
-
-
-.sponsor-description {
-  margin: 0;
-  color: var(--text-muted);
-  line-height: 1.8;
-  text-transform: none;
-  letter-spacing: normal;
-}
-
-.sponsor-description + .sponsor-description {
-  margin-top: 0.9rem;
-}
-
-.sponsor-cta {
-  display: inline-flex;
-  width: fit-content;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid rgba(147, 98, 255, 0.95);
-  border-radius: 0.95rem;
-  min-height: 44px;
-  padding: 0.65rem 1.1rem;
-  font-size: 0.84rem;
-  font-weight: 800;
-  color: #ecf5ff;
-  background: linear-gradient(180deg, #a587ff 0%, #7d56ff 100%);
+  line-height: 1.78;
+  max-width: 42ch;
 }
 
 .panel-section,
 .faq,
 .about-section {
-  padding: clamp(3rem, 5.3vw, 3.6rem);
+  padding: clamp(2.25rem, 4.8vw, 3.25rem);
 }
 
 .panel-section p,
@@ -414,62 +369,104 @@ summary:focus-visible,
   justify-content: space-between;
   align-items: center;
   gap: 0.7rem;
-  margin-bottom: 0.65rem;
+  margin-bottom: 0.6rem;
 }
 
 .system-panel-hint {
-  margin-bottom: 0.9rem;
+  margin-bottom: 0.75rem;
   color: #9fe8ff;
   font-weight: 600;
 }
 
 .system-panel-indicator {
-  font-size: 1.25rem;
+  font-size: 1.2rem;
   color: #94e9ff;
 }
 
 .faq details {
-  border: 1px solid rgba(106, 184, 255, 0.38);
+  border: 1px solid rgba(79, 173, 255, 0.36);
   border-radius: var(--radius-md);
-  background: rgba(13, 19, 42, 0.82);
-  padding: 1.4rem 1.5rem;
-  margin-bottom: 1.2rem;
+  background: rgba(10, 16, 34, 0.75);
+  padding: 1rem 1.1rem;
 }
 
-.faq details[open] {
-  padding-bottom: 1.5rem;
-}
+.faq details + details { margin-top: 0.95rem; }
 
 .faq summary {
   cursor: pointer;
   font-weight: 700;
-  color: #aeeeff;
+  color: #9beaff;
 }
 
 .faq details p {
-  margin: 1rem 0 0;
-  padding-top: 0.5rem;
+  margin: 0.8rem 0 0;
   color: var(--text-muted);
-  line-height: 1.85;
+  line-height: 1.8;
 }
 
 .about-section p {
   margin: 0.9rem 0 0;
 }
 
+.sponsor-card {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.sponsor-card .league-card-content {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.sponsor-description {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.8;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.sponsor-description + .sponsor-description {
+  margin-top: 0.85rem;
+}
+
+.sponsor-cta {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(124, 77, 255, 0.95);
+  border-radius: 0.9rem;
+  min-height: 44px;
+  padding: 0.62rem 1.05rem;
+  font-size: 0.83rem;
+  font-weight: 800;
+  color: #ecf5ff;
+  background: linear-gradient(180deg, #9d79ff 0%, #7c4dff 100%);
+}
+
 .donations-section h2 {
   text-transform: none;
 }
 
+.donation-intro {
+  margin: 0;
+  font-family: "Orbitron", "Inter", sans-serif;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #9fe8ff;
+}
+
 .donation-actions {
-  margin-top: 1.4rem;
+  margin-top: 1.2rem;
   justify-content: flex-start;
 }
 
 .donation-goal {
   display: grid;
-  gap: 0.7rem;
-  margin-top: 1.4rem;
+  gap: 0.65rem;
+  margin-top: 1.25rem;
 }
 
 .donation-goal-text {
@@ -483,8 +480,8 @@ summary:focus-visible,
 .donation-goal-track {
   width: 100%;
   border-radius: 999px;
-  border: 1px solid rgba(89, 172, 255, 0.48);
-  background: rgba(5, 11, 28, 0.88);
+  border: 1px solid rgba(79, 173, 255, 0.45);
+  background: rgba(7, 11, 27, 0.88);
   height: 14px;
   overflow: hidden;
 }
@@ -493,21 +490,21 @@ summary:focus-visible,
   display: block;
   width: 0;
   height: 100%;
-  background: linear-gradient(90deg, #8df0ff 0%, #38d2ff 60%, #7d56ff 100%);
-  box-shadow: 0 0 0.8rem rgba(67, 212, 255, 0.5);
+  background: linear-gradient(90deg, #7bf0ff 0%, #2bd6ff 58%, #7c4dff 100%);
+  box-shadow: 0 0 0.75rem rgba(43, 214, 255, 0.45);
 }
 
 .donation-transfer-card {
-  margin-top: 1.2rem;
-  border: 1px solid rgba(103, 190, 255, 0.36);
+  margin-top: 1.1rem;
+  border: 1px solid rgba(86, 178, 255, 0.36);
   border-radius: var(--radius-md);
-  background: rgba(8, 13, 33, 0.86);
+  background: rgba(9, 13, 31, 0.85);
   padding: 1rem;
 }
 
 .donation-transfer-card h3 {
-  margin: 0 0 0.8rem;
-  font-size: clamp(1rem, 2.1vw, 1.15rem);
+  margin: 0 0 0.75rem;
+  font-size: clamp(1rem, 2.1vw, 1.12rem);
 }
 
 .donation-transfer-item {
@@ -515,10 +512,9 @@ summary:focus-visible,
 }
 
 .donation-transfer-note {
-  margin: 0.8rem 0 0;
+  margin: 0.75rem 0 0;
   color: var(--text-muted);
 }
-
 
 .note-text {
   color: var(--text-muted);
@@ -538,8 +534,8 @@ summary:focus-visible,
 .history-accordion-item {
   padding: 1rem;
   border-radius: var(--radius-md);
-  border: 1px solid rgba(103, 190, 255, 0.36);
-  background: rgba(8, 13, 33, 0.86);
+  border: 1px solid rgba(86, 178, 255, 0.36);
+  background: rgba(9, 13, 31, 0.85);
 }
 
 .palmares-grid {
@@ -548,10 +544,10 @@ summary:focus-visible,
 }
 
 .palmares-card {
-  border: 1px solid rgba(93, 174, 255, 0.35);
+  border: 1px solid rgba(76, 166, 250, 0.35);
   border-radius: 0.85rem;
   padding: 0.85rem;
-  background: rgba(10, 16, 37, 0.86);
+  background: rgba(11, 16, 35, 0.84);
 }
 
 .palmares-trophy,
@@ -572,7 +568,7 @@ summary:focus-visible,
 
 .pes6-ranking-row,
 .history-row {
-  border: 1px solid rgba(98, 182, 255, 0.33);
+  border: 1px solid rgba(84, 172, 255, 0.33);
   border-radius: 0.85rem;
   padding: 0.75rem;
   background: rgba(11, 16, 35, 0.8);
@@ -687,7 +683,7 @@ summary:focus-visible,
   padding: 0.9rem;
   background: rgba(5, 11, 28, 0.88);
   color: var(--text-main);
-  line-height: 1.65;
+  line-height: 1.6;
 }
 
 .highlight-text {
@@ -728,7 +724,7 @@ summary:focus-visible,
 @media (max-width: 768px) {
   .section {
     width: min(1120px, 94%);
-    padding: clamp(3rem, 10vw, 4rem) 0;
+    padding: clamp(2.8rem, 10vw, 3.8rem) 0;
   }
 
   .hero-copy,
@@ -760,7 +756,7 @@ summary:focus-visible,
   .panel-section,
   .faq,
   .about-section {
-    padding: 1.6rem;
+    padding: 1.35rem;
   }
 
   .season-card-header {
@@ -770,12 +766,7 @@ summary:focus-visible,
 
   .league-card-banner,
   .modal-banner {
-    height: 250px;
-  }
-
-  .season-end {
-    font-size: clamp(1.05rem, 5.5vw, 1.35rem);
-    padding: 1.1rem;
+    height: 230px;
   }
 
   .league-modal {
@@ -783,9 +774,5 @@ summary:focus-visible,
     width: 95vw;
     max-height: 95vh;
     padding: 1rem;
-  }
-
-  .donation-actions {
-    margin-top: 1rem;
   }
 }


### PR DESCRIPTION
### Motivation
- Volver la apariencia del sitio al estilo visual original (paleta azul, tipografía gamer) y retirar los ajustes visuales más pro/futuristas añadidos posteriormente sin tocar la organización ni el layout de las secciones.
- Mantener la sección de Sponsor intacta y preservar su contenido y soporte visual dentro del diseño restaurado.
- Conservar y adaptar la sección de Donaciones al estilo original y reemplazar el placeholder por el texto solicitado exactamente.

### Description
- Revertí/ajusté la hoja de estilos para restaurar la estética original modificando `styles.css` (colores, sombras, tipografía principal y reglas visuales) sin cambiar la estructura DOM ni el layout de secciones. 
- Restauré y mantuve las reglas visuales del `Sponsor` para que siga mostrándose igual dentro del tema restaurado. 
- Reemplacé el placeholder de donaciones en `index.html` por el texto requerido exactamente usando una línea con `💙 Apoyá Sudaka League` y la línea siguiente `Sudaka League es un proyecto independiente, s`. 
- Añadí reglas CSS específicas para la introducción y los elementos de la sección de donaciones (`.donation-intro`, barra de progreso y tarjeta de transferencia) para integrarla al estilo azul + gamer.

### Testing
- Ejecuté la verificación de sintaxis de JavaScript con `node --check app.js` y la comprobación completó con éxito. 
- Levanté un servidor local con `python -m http.server 4173` y verifiqué que `index.html` respondía (cabeceras HTTP 200) pero la captura via Playwright falló con `net::ERR_EMPTY_RESPONSE` al intentar cargar la página en este entorno, por lo que no se adjuntó screenshot automatizado. 
- Se revisaron manualmente los cambios en `index.html` y `styles.css` para asegurar que solo la estética fue modificada y la estructura/layout se mantuvo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a7dd16a148332bd1be4826e07424e)