### PR TITLE
Restaurar theme original 1:1 y unificar estilo global

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
   <meta name="description" content="Sudaka League - Comunidad de juegos retro online con formato competitivo." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css?v=20260210-visual" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&family=Orbitron:wght@600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css?v=20260210-theme-original" />
 </head>
 <body>
   <div class="bg-effects" aria-hidden="true"></div>

--- a/styles.css
+++ b/styles.css
@@ -1,36 +1,37 @@
 :root {
-  --bg-0: #040913;
-  --bg-1: #091326;
-  --bg-2: #0f1d38;
-  --surface: #121f3a;
-  --surface-soft: #172849;
-  --surface-strong: #1c3158;
-  --text-main: #eef4ff;
-  --text-soft: #c4d4f4;
-  --text-muted: #98add4;
-  --line: rgba(120, 166, 255, 0.35);
-  --line-strong: rgba(125, 184, 255, 0.7);
-  --glow: 0 0 0 1px rgba(118, 172, 255, 0.2), 0 18px 40px rgba(4, 15, 40, 0.6);
-  --shadow-soft: 0 14px 32px rgba(3, 10, 26, 0.52);
-  --radius-lg: 18px;
-  --radius-md: 12px;
+  --bg-main: #06060f;
+  --bg-alt: #0d0b1d;
+  --bg-surface: rgba(18, 16, 40, 0.88);
+  --bg-surface-strong: rgba(12, 12, 29, 0.96);
+  --bg-card: linear-gradient(160deg, rgba(26, 21, 56, 0.92) 0%, rgba(14, 13, 33, 0.96) 55%, rgba(7, 9, 22, 0.98) 100%);
+  --text-main: #f3f7ff;
+  --text-soft: #c2c8e8;
+  --text-muted: #a3abd1;
+  --line: rgba(99, 225, 255, 0.5);
+  --line-strong: rgba(157, 120, 255, 0.95);
+  --radius-lg: 1.3rem;
+  --radius-md: 1rem;
+  --shadow-soft: 0 26px 60px rgba(2, 4, 15, 0.6);
+  --shadow-glow: 0 0 1.2rem rgba(82, 211, 255, 0.26);
 }
 
 * { box-sizing: border-box; }
+
 html { scroll-behavior: smooth; }
 
 body {
   margin: 0;
   min-height: 100vh;
   overflow-x: hidden;
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: "Inter", system-ui, sans-serif;
   font-size: 16px;
-  line-height: 1.7;
+  line-height: 1.75;
   color: var(--text-main);
   background:
-    radial-gradient(circle at 10% 8%, rgba(71, 134, 255, 0.22), transparent 34%),
-    radial-gradient(circle at 90% 12%, rgba(47, 109, 238, 0.16), transparent 38%),
-    linear-gradient(160deg, var(--bg-0) 0%, var(--bg-1) 55%, #060d1d 100%);
+    radial-gradient(circle at 10% 0%, rgba(81, 237, 255, 0.2), transparent 38%),
+    radial-gradient(circle at 84% 6%, rgba(158, 96, 255, 0.24), transparent 42%),
+    radial-gradient(circle at 56% 86%, rgba(50, 34, 118, 0.38), transparent 46%),
+    linear-gradient(160deg, var(--bg-alt) 0%, #06070f 45%, #050509 100%);
 }
 
 body.no-scroll { overflow: hidden; }
@@ -40,17 +41,19 @@ body.no-scroll { overflow: hidden; }
   inset: 0;
   z-index: -1;
   pointer-events: none;
-  opacity: 0.55;
-  background:
-    radial-gradient(circle at 20% 30%, rgba(145, 190, 255, 0.12) 0 2px, transparent 2px),
-    radial-gradient(circle at 80% 70%, rgba(129, 182, 255, 0.1) 0 2px, transparent 2px),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 24%);
+  opacity: 0.8;
+  mix-blend-mode: screen;
+  background-image:
+    linear-gradient(120deg, rgba(255, 255, 255, 0.035), transparent 28%),
+    repeating-linear-gradient(to bottom, rgba(255, 255, 255, 0.02) 0, rgba(255, 255, 255, 0.02) 1px, transparent 3px, transparent 6px),
+    radial-gradient(circle at 18% 26%, rgba(43, 214, 255, 0.18) 0 2px, transparent 2px),
+    radial-gradient(circle at 82% 72%, rgba(154, 122, 255, 0.2) 0 2px, transparent 2px);
 }
 
 .section {
   width: min(1180px, 92%);
   margin: 0 auto;
-  padding: clamp(4rem, 8vw, 6rem) 0;
+  padding: clamp(4.5rem, 8vw, 6.7rem) 0;
 }
 
 h1,
@@ -60,106 +63,92 @@ h3,
 .btn,
 .tab-btn,
 .season-badge {
-  letter-spacing: 0.01em;
-  font-family: "Inter", system-ui, sans-serif;
+  font-family: "Orbitron", "Inter", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+h1,
+h2,
+.league-card-content h3,
+.league-modal h2,
+.league-modal h3 {
+  text-shadow: 0 0 0.4rem rgba(99, 225, 255, 0.5), 0 0 1rem rgba(148, 108, 255, 0.28);
 }
 
 h2 {
   margin: 0 0 2rem;
-  font-size: clamp(1.35rem, 2.8vw, 1.95rem);
-  line-height: 1.28;
+  font-size: clamp(1.35rem, 2.9vw, 2rem);
+  line-height: 1.3;
 }
 
 p,
-li { margin-top: 0; }
+li {
+  margin-top: 0;
+  line-height: 1.75;
+}
 
 .hero {
   text-align: center;
-  padding-top: clamp(5rem, 9vw, 7rem);
+  padding-top: clamp(5.1rem, 9vw, 8rem);
 }
 
 .hero-kicker {
   margin: 0;
-  color: #9ebeff;
-  font-size: 0.84rem;
-  text-transform: uppercase;
-  font-weight: 700;
+  color: #a3d4ff;
+  font-size: 0.86rem;
 }
 
 .hero h1 {
-  margin: 1rem 0 0.9rem;
-  font-size: clamp(2.6rem, 10vw, 6rem);
-  line-height: 0.95;
-  font-weight: 800;
+  margin: 1.5rem 0 1rem;
+  font-size: clamp(2.9rem, 11vw, 6.8rem);
+  line-height: 0.92;
 }
 
 .subtitle,
 .hero-copy {
   margin-inline: auto;
   color: var(--text-soft);
-  max-width: 72ch;
+  max-width: 70ch;
 }
 
 .subtitle {
-  margin-bottom: 1.05rem;
-  font-weight: 600;
+  margin-bottom: 1.2rem;
+  font-weight: 700;
 }
 
 .hero-actions {
-  margin-top: 2.1rem;
+  margin-top: 2.4rem;
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 0.95rem;
-}
-
-.card,
-.panel-section,
-.faq,
-.league-card,
-.league-modal,
-.season-card,
-.palmares-block,
-.pes6-ranking,
-.season-status {
-  border: 1px solid var(--line);
-  border-radius: var(--radius-lg);
-  background: linear-gradient(165deg, rgba(23, 38, 70, 0.94) 0%, rgba(14, 26, 50, 0.95) 100%);
-  box-shadow: var(--glow), var(--shadow-soft);
-}
-
-.hud-separator { position: relative; }
-.hud-separator::after {
-  content: "";
-  position: absolute;
-  left: 5%;
-  right: 5%;
-  bottom: -0.2rem;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(126, 176, 255, 0.75), transparent);
+  gap: 1rem;
 }
 
 .btn {
-  border: 1px solid var(--line-strong);
-  border-radius: 11px;
-  min-height: 48px;
-  padding: 0.82rem 1.3rem;
-  font-size: 0.88rem;
-  font-weight: 700;
+  border: 1px solid var(--line);
+  border-radius: 0.95rem;
+  min-height: 52px;
+  padding: 0.9rem 1.4rem;
+  font-size: 0.86rem;
+  font-weight: 800;
   text-decoration: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: #f2f7ff;
-  background: linear-gradient(180deg, #2f63ba 0%, #224c98 100%);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15), 0 10px 22px rgba(4, 17, 44, 0.45);
+  color: #ecf5ff;
+  background: linear-gradient(180deg, rgba(23, 20, 49, 0.98), rgba(11, 10, 28, 0.96));
+  box-shadow: inset 0 0 0 1px rgba(124, 77, 255, 0.24), 0 0 0.95rem rgba(69, 201, 255, 0.2);
   cursor: pointer;
-  transition: transform 180ms ease, box-shadow 220ms ease, filter 180ms ease;
+  transition: transform 180ms ease, box-shadow 220ms ease, filter 200ms ease;
+}
+
+.btn-primary {
+  color: #051720;
+  border-color: #50d8ff;
+  background: linear-gradient(180deg, #8df0ff 0%, #38d2ff 100%);
 }
 
 .btn-secondary {
-  border-color: rgba(121, 170, 255, 0.55);
-  background: linear-gradient(180deg, rgba(43, 77, 139, 0.95), rgba(30, 55, 104, 0.98));
+  border-color: rgba(147, 98, 255, 0.95);
+  background: linear-gradient(180deg, #a587ff 0%, #7d56ff 100%);
 }
 
 .btn:hover,
@@ -169,7 +158,8 @@ li { margin-top: 0; }
 .league-card:hover,
 .season-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 0 0 1px rgba(127, 181, 255, 0.42), 0 16px 28px rgba(7, 23, 58, 0.6);
+  filter: brightness(1.06);
+  box-shadow: 0 0 1rem rgba(83, 219, 255, 0.4), 0 0 1.8rem rgba(142, 105, 255, 0.3);
 }
 
 .btn:focus-visible,
@@ -178,33 +168,56 @@ li { margin-top: 0; }
 summary:focus-visible,
 .close-btn:focus-visible,
 .tab-btn:focus-visible {
-  outline: 2px solid #9ec4ff;
+  outline: 2px solid #9fd2ff;
   outline-offset: 2px;
 }
 
-.badge,
-.season-badge,
-.mini-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  font-size: 0.72rem;
-  letter-spacing: 0.04em;
-  font-weight: 700;
-  text-transform: uppercase;
+.hud-separator {
+  position: relative;
 }
 
-.season-status { padding: clamp(2.8rem, 5.4vw, 3.5rem); }
-.season-status h2 { margin-bottom: 2rem; }
+.hud-separator::after {
+  content: "";
+  position: absolute;
+  left: 6%;
+  right: 6%;
+  bottom: -0.45rem;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, #38d2ff, #8b65ff, transparent);
+  filter: drop-shadow(0 0 0.5rem rgba(67, 214, 255, 0.8));
+}
+
+.panel-section,
+.faq,
+.league-card,
+.league-modal,
+.season-card,
+.palmares-block,
+.pes6-ranking,
+.season-status {
+  border: 1px solid rgba(86, 223, 255, 0.46);
+  border-radius: var(--radius-lg);
+  background: var(--bg-card);
+  box-shadow: inset 0 0 0 1px rgba(137, 95, 255, 0.24), var(--shadow-glow), var(--shadow-soft);
+}
+
+.season-status {
+  padding: clamp(3rem, 5.4vw, 3.8rem);
+}
+
+.season-status h2 {
+  margin-bottom: 2.2rem;
+}
 
 .season-grid,
 .league-grid {
   display: grid;
-  gap: clamp(1.3rem, 2.8vw, 1.8rem);
+  gap: clamp(1.6rem, 2.9vw, 2rem);
 }
 
-.season-card { padding: clamp(1.6rem, 3vw, 2.1rem); }
+.season-card {
+  padding: clamp(1.8rem, 3.3vw, 2.4rem);
+}
 
 .season-card-header {
   display: flex;
@@ -214,33 +227,63 @@ summary:focus-visible,
   margin-bottom: 1rem;
 }
 
-.season-card h3 { margin: 0; font-size: clamp(1rem, 2vw, 1.15rem); }
+.season-card h3 {
+  margin: 0;
+  font-size: clamp(1rem, 2vw, 1.2rem);
+}
+
 .season-title,
-.season-note { margin-bottom: 1.15rem; color: var(--text-soft); }
-.season-countdown-label { margin: 1rem 0 1.3rem; }
+.season-note {
+  margin-bottom: 1.2rem;
+  color: var(--text-soft);
+}
+
+.season-countdown-label {
+  margin: 1.2rem 0 1.6rem;
+}
 
 .season-end {
   display: block;
   width: 100%;
-  border: 1px solid rgba(124, 175, 255, 0.56);
-  border-radius: 12px;
-  padding: 1.1rem;
-  font-size: clamp(1.12rem, 3vw, 1.65rem);
+  border: 1px solid rgba(79, 228, 255, 0.62);
+  border-radius: 1rem;
+  padding: 1.4rem 1.2rem;
+  font-family: "Orbitron", "Inter", sans-serif;
+  font-size: clamp(1.25rem, 3.2vw, 1.8rem);
   text-align: center;
-  background: linear-gradient(165deg, rgba(34, 56, 99, 0.95), rgba(22, 39, 72, 0.98));
+  letter-spacing: 0.06em;
+  background: linear-gradient(165deg, rgba(16, 52, 76, 0.9), rgba(18, 22, 51, 0.95));
+  box-shadow: inset 0 0 0 1px rgba(128, 221, 255, 0.3), 0 0 1.4rem rgba(67, 212, 255, 0.24);
 }
 
-.season-badge { padding: 0.34rem 0.72rem; border: 1px solid transparent; }
-.season-badge-active {
-  color: #eff6ff;
-  border-color: rgba(132, 189, 255, 0.9);
-  background: linear-gradient(180deg, #3a79d6 0%, #295eb0 100%);
+.season-badge,
+.mini-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  font-weight: 700;
+  white-space: nowrap;
 }
+
+.season-badge {
+  padding: 0.36rem 0.75rem;
+}
+
+.season-badge-active {
+  color: #042530;
+  border-color: #4bdfff;
+  background: linear-gradient(180deg, #95f2ff, #38d2ff);
+}
+
 .season-badge-wait,
 .season-badge-ended {
-  color: #e8f1ff;
-  border-color: rgba(126, 168, 239, 0.58);
-  background: linear-gradient(180deg, #47608f 0%, #34486e 100%);
+  color: #fbf2ff;
+  border-color: rgba(138, 94, 255, 0.9);
+  background: linear-gradient(180deg, #b096ff, #7e57ff);
 }
 
 .season-slots {
@@ -249,22 +292,34 @@ summary:focus-visible,
   align-items: center;
   gap: 0.7rem;
   margin-top: 0.6rem;
-  padding-top: 0.95rem;
-  border-top: 1px solid rgba(124, 170, 248, 0.28);
+  padding-top: 1rem;
+  border-top: 1px solid rgba(88, 168, 255, 0.3);
   color: var(--text-soft);
 }
 
 .season-slots-label { font-weight: 600; }
-.season-slots-value { color: var(--text-main); font-weight: 700; }
+
+.season-slots-value {
+  color: var(--text-main);
+  font-weight: 700;
+}
 
 .mini-badge {
-  padding: 0.24rem 0.62rem;
-  border: 1px solid rgba(122, 170, 255, 0.5);
-  color: #e3efff;
-  background: rgba(27, 47, 86, 0.8);
+  padding: 0.24rem 0.65rem;
+  border-color: rgba(72, 217, 255, 0.38);
+  background: rgba(18, 33, 70, 0.75);
+  color: #dbf3ff;
 }
-.mini-badge--open { border-color: rgba(135, 196, 255, 0.8); }
-.mini-badge--closed { border-color: rgba(132, 157, 204, 0.65); }
+
+.mini-badge--open {
+  border-color: rgba(76, 255, 194, 0.6);
+  color: #aaffdf;
+}
+
+.mini-badge--closed {
+  border-color: rgba(255, 134, 179, 0.62);
+  color: #ffd5e7;
+}
 
 .league-card {
   overflow: hidden;
@@ -280,17 +335,22 @@ summary:focus-visible,
   object-position: center;
 }
 
-.league-card-content { padding: 1.75rem; }
-.league-card-content h3 {
-  margin: 0 0 0.85rem;
-  font-size: clamp(1.05rem, 2.2vw, 1.22rem);
+.league-card-content {
+  padding: 2rem;
 }
+
+.league-card-content h3 {
+  margin: 0 0 1rem;
+  font-size: clamp(1.06rem, 2.2vw, 1.3rem);
+}
+
 .league-card-content p {
   margin: 0;
   color: var(--text-soft);
-  line-height: 1.75;
+  line-height: 1.85;
   max-width: 60ch;
 }
+
 
 .sponsor-card {
   display: block;
@@ -306,32 +366,34 @@ summary:focus-visible,
 .sponsor-description {
   margin: 0;
   color: var(--text-muted);
-  line-height: 1.8;
+  line-height: 1.85;
   text-transform: none;
   letter-spacing: normal;
 }
 
-.sponsor-description + .sponsor-description { margin-top: 0.9rem; }
+.sponsor-description + .sponsor-description {
+  margin-top: 0.9rem;
+}
 
 .sponsor-cta {
   display: inline-flex;
   width: fit-content;
   align-items: center;
   justify-content: center;
-  border: 1px solid rgba(126, 170, 248, 0.9);
-  border-radius: 11px;
+  border: 1px solid rgba(147, 98, 255, 0.95);
+  border-radius: 0.95rem;
   min-height: 44px;
   padding: 0.65rem 1.1rem;
   font-size: 0.84rem;
-  font-weight: 700;
-  color: #edf5ff;
-  background: linear-gradient(180deg, #4771bf 0%, #32589f 100%);
+  font-weight: 800;
+  color: #ecf5ff;
+  background: linear-gradient(180deg, #a587ff 0%, #7d56ff 100%);
 }
 
 .panel-section,
 .faq,
 .about-section {
-  padding: clamp(2.8rem, 5.2vw, 3.4rem);
+  padding: clamp(3rem, 5.3vw, 3.6rem);
 }
 
 .panel-section p,
@@ -342,46 +404,66 @@ summary:focus-visible,
   max-width: 70ch;
 }
 
-.system-panel-trigger { cursor: pointer; }
+.system-panel-trigger {
+  cursor: pointer;
+}
+
 .system-panel-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 0.7rem;
-  margin-bottom: 0.6rem;
+  margin-bottom: 0.65rem;
 }
-.system-panel-hint { margin-bottom: 0.9rem; color: #d4e6ff; font-weight: 600; }
-.system-panel-indicator { font-size: 1.25rem; color: #b9d2ff; }
+
+.system-panel-hint {
+  margin-bottom: 0.9rem;
+  color: #9fe8ff;
+  font-weight: 600;
+}
+
+.system-panel-indicator {
+  font-size: 1.25rem;
+  color: #94e9ff;
+}
 
 .faq details {
-  border: 1px solid rgba(121, 166, 240, 0.33);
+  border: 1px solid rgba(106, 184, 255, 0.38);
   border-radius: var(--radius-md);
-  background: rgba(20, 35, 66, 0.84);
-  padding: 1.25rem 1.3rem;
-  margin-bottom: 1rem;
+  background: rgba(13, 19, 42, 0.82);
+  padding: 1.4rem 1.5rem;
+  margin-bottom: 1.2rem;
 }
-.faq details[open] { padding-bottom: 1.35rem; }
-.faq summary { cursor: pointer; font-weight: 700; color: #e2eeff; }
+
+.faq details[open] {
+  padding-bottom: 1.5rem;
+}
+
+.faq summary {
+  cursor: pointer;
+  font-weight: 700;
+  color: #aeeeff;
+}
+
 .faq details p {
-  margin: 0.95rem 0 0;
-  padding-top: 0.4rem;
+  margin: 1rem 0 0;
+  padding-top: 0.5rem;
   color: var(--text-muted);
-  line-height: 1.78;
+  line-height: 1.85;
 }
 
-.about-section p { margin: 0.85rem 0 0; }
+.about-section p {
+  margin: 0.9rem 0 0;
+}
 
-.donations-section h2 { text-transform: none; }
+.donations-section h2 {
+  text-transform: none;
+}
 
 .donation-copy {
   white-space: pre-line;
   color: var(--text-soft);
   margin-bottom: 0;
-}
-
-.donation-actions {
-  margin-top: 1.2rem;
-  justify-content: flex-start;
 }
 
 .donation-goal {
@@ -392,15 +474,17 @@ summary:focus-visible,
 
 .donation-goal-text {
   margin: 0;
-  font-weight: 700;
-  color: #deebff;
+  font-family: "Orbitron", "Inter", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #aeeeff;
 }
 
 .donation-goal-track {
   width: 100%;
   border-radius: 999px;
-  border: 1px solid rgba(124, 170, 248, 0.55);
-  background: rgba(13, 23, 43, 0.95);
+  border: 1px solid rgba(79, 228, 255, 0.62);
+  background: rgba(8, 13, 33, 0.86);
   height: 14px;
   overflow: hidden;
 }
@@ -409,15 +493,20 @@ summary:focus-visible,
   display: block;
   width: 0;
   height: 100%;
-  background: linear-gradient(90deg, #67a0ff 0%, #4c80de 65%, #3762b6 100%);
-  box-shadow: 0 0 12px rgba(107, 159, 255, 0.6);
+  background: linear-gradient(90deg, #89efff 0%, #38d2ff 100%);
+  box-shadow: 0 0 0.8rem rgba(67, 212, 255, 0.5);
+}
+
+.donation-actions {
+  margin-top: 1.2rem;
+  justify-content: flex-start;
 }
 
 .donation-transfer-card {
   margin-top: 1.2rem;
-  border: 1px solid rgba(124, 170, 248, 0.38);
+  border: 1px solid rgba(103, 190, 255, 0.36);
   border-radius: var(--radius-md);
-  background: rgba(20, 35, 65, 0.86);
+  background: rgba(8, 13, 33, 0.86);
   padding: 1rem;
 }
 
@@ -426,13 +515,25 @@ summary:focus-visible,
   font-size: clamp(1rem, 2.1vw, 1.14rem);
 }
 
-.donation-transfer-item { margin: 0.2rem 0; }
-.donation-transfer-note { margin: 0.75rem 0 0; color: var(--text-muted); }
+.donation-transfer-item {
+  margin: 0.2rem 0;
+}
 
-.note-text { color: var(--text-muted); font-style: italic; }
+.donation-transfer-note {
+  margin: 0.75rem 0 0;
+  color: var(--text-muted);
+}
+
+.note-text {
+  color: var(--text-muted);
+  font-style: italic;
+}
 
 .history-layout,
-.palmares-layout { display: grid; gap: 1rem; }
+.palmares-layout {
+  display: grid;
+  gap: 1rem;
+}
 
 .palmares-block,
 .pes6-ranking,
@@ -441,17 +542,20 @@ summary:focus-visible,
 .history-accordion-item {
   padding: 1rem;
   border-radius: var(--radius-md);
-  border: 1px solid rgba(124, 170, 248, 0.35);
-  background: rgba(20, 35, 65, 0.86);
+  border: 1px solid rgba(103, 190, 255, 0.36);
+  background: rgba(8, 13, 33, 0.86);
 }
 
-.palmares-grid { display: grid; gap: 0.8rem; }
+.palmares-grid {
+  display: grid;
+  gap: 0.8rem;
+}
 
 .palmares-card {
-  border: 1px solid rgba(124, 170, 248, 0.35);
-  border-radius: 11px;
-  padding: 0.82rem;
-  background: rgba(22, 39, 72, 0.88);
+  border: 1px solid rgba(93, 174, 255, 0.35);
+  border-radius: 0.85rem;
+  padding: 0.85rem;
+  background: rgba(10, 16, 37, 0.86);
 }
 
 .palmares-trophy,
@@ -463,8 +567,8 @@ summary:focus-visible,
 
 .palmares-subtitle,
 .pes6-ranking-subtitle {
-  margin: 0 0 0.72rem;
-  color: #dceaff;
+  margin: 0 0 0.75rem;
+  color: #a8ecff;
   font-weight: 700;
 }
 
@@ -472,10 +576,10 @@ summary:focus-visible,
 
 .pes6-ranking-row,
 .history-row {
-  border: 1px solid rgba(124, 170, 248, 0.35);
-  border-radius: 11px;
+  border: 1px solid rgba(98, 182, 255, 0.33);
+  border-radius: 0.85rem;
   padding: 0.75rem;
-  background: rgba(21, 37, 69, 0.86);
+  background: rgba(11, 16, 35, 0.8);
 }
 
 .pes6-ranking-header,
@@ -490,22 +594,27 @@ summary:focus-visible,
 .history-accordion-panel {
   margin-top: 0.65rem;
   padding-top: 0.65rem;
-  border-top: 1px solid rgba(120, 165, 239, 0.3);
+  border-top: 1px solid rgba(83, 169, 255, 0.26);
 }
 
 .pes6-ranking-toggle,
 .history-accordion-trigger {
-  border: 1px solid rgba(124, 170, 248, 0.55);
-  border-radius: 10px;
-  background: rgba(27, 47, 86, 0.9);
-  color: #e7f1ff;
-  padding: 0.4rem 0.7rem;
+  border: 1px solid rgba(83, 165, 255, 0.5);
+  border-radius: 0.7rem;
+  background: rgba(11, 22, 46, 0.88);
+  color: #d5ecff;
+  padding: 0.42rem 0.7rem;
   font-weight: 700;
   cursor: pointer;
 }
 
-.history-value.is-pending { color: #e1ecff; }
-.history-pending-badge { margin-left: 0.5rem; font-size: 0.75rem; color: #d5e6ff; }
+.history-value.is-pending { color: #ffd2ec; }
+
+.history-pending-badge {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  color: #ffd7ec;
+}
 
 .league-modal {
   position: fixed;
@@ -515,25 +624,25 @@ summary:focus-visible,
   max-height: 92vh;
   overflow: auto;
   z-index: 60;
-  padding: clamp(1.2rem, 3vw, 1.9rem);
+  padding: clamp(1.25rem, 3vw, 2rem);
 }
 
 .modal-overlay {
   position: fixed;
   inset: 0;
   z-index: 50;
-  background: rgba(5, 10, 22, 0.78);
-  backdrop-filter: blur(4px);
+  background: rgba(1, 3, 9, 0.76);
+  backdrop-filter: blur(3px);
 }
 
 .close-btn {
   position: sticky;
   top: 0;
   float: right;
-  border: 1px solid rgba(124, 170, 248, 0.6);
-  border-radius: 10px;
-  background: rgba(23, 40, 75, 0.95);
-  color: #edf5ff;
+  border: 1px solid rgba(112, 190, 255, 0.55);
+  border-radius: 0.72rem;
+  background: rgba(8, 21, 44, 0.94);
+  color: #d7ecff;
   font-size: 1.25rem;
   line-height: 1;
   width: 2.1rem;
@@ -542,27 +651,27 @@ summary:focus-visible,
 }
 
 .tab-bar {
-  margin: 1.2rem 0 1.2rem;
+  margin: 1.2rem 0 1.25rem;
   display: flex;
-  gap: 0.65rem;
+  gap: 0.7rem;
   flex-wrap: wrap;
 }
 
 .tab-btn {
-  border: 1px solid rgba(124, 170, 248, 0.55);
-  border-radius: 10px;
-  background: rgba(24, 43, 79, 0.9);
-  color: #e4efff;
+  border: 1px solid rgba(96, 176, 255, 0.52);
+  border-radius: 0.75rem;
+  background: rgba(10, 20, 42, 0.9);
+  color: #d9edff;
   font-size: 0.74rem;
   font-weight: 700;
-  padding: 0.54rem 0.75rem;
+  padding: 0.55rem 0.75rem;
   cursor: pointer;
 }
 
 .tab-btn.is-active {
-  color: #f1f7ff;
-  border-color: rgba(140, 194, 255, 0.95);
-  background: linear-gradient(180deg, #3f7ce2, #2a5bb4);
+  color: #04131a;
+  border-color: #2bd6ff;
+  background: linear-gradient(180deg, #89efff, #2bd6ff);
 }
 
 .tab-panel[hidden] { display: none; }
@@ -570,25 +679,25 @@ summary:focus-visible,
 .copy-box {
   display: grid;
   gap: 0.7rem;
-  margin-top: 1.1rem;
+  margin-top: 1.15rem;
 }
 
 .copy-box textarea {
   width: 100%;
   min-height: 135px;
   resize: vertical;
-  border-radius: 12px;
-  border: 1px solid rgba(124, 170, 248, 0.5);
+  border-radius: 0.95rem;
+  border: 1px solid rgba(89, 172, 255, 0.48);
   padding: 0.9rem;
-  background: rgba(14, 25, 49, 0.94);
+  background: rgba(5, 11, 28, 0.88);
   color: var(--text-main);
   line-height: 1.65;
 }
 
 .highlight-text {
-  border-left: 3px solid rgba(132, 189, 255, 0.85);
-  padding-left: 0.72rem;
-  color: #daebff;
+  border-left: 3px solid rgba(123, 206, 255, 0.72);
+  padding-left: 0.7rem;
+  color: #bfe9ff;
 }
 
 .back-to-top {
@@ -630,13 +739,15 @@ summary:focus-visible,
   .subtitle,
   .panel-section p,
   .faq p,
-  .about-section p { max-width: 100%; }
+  .about-section p {
+    max-width: 100%;
+  }
 
   .hero-actions {
     width: 100%;
     flex-direction: column;
     align-items: stretch;
-    gap: 0.82rem;
+    gap: 0.85rem;
   }
 
   .hero-actions .btn,
@@ -652,7 +763,9 @@ summary:focus-visible,
   .league-card-content,
   .panel-section,
   .faq,
-  .about-section { padding: 1.4rem; }
+  .about-section {
+    padding: 1.6rem;
+  }
 
   .season-card-header {
     align-items: flex-start;
@@ -660,11 +773,13 @@ summary:focus-visible,
   }
 
   .league-card-banner,
-  .modal-banner { height: 250px; }
+  .modal-banner {
+    height: 250px;
+  }
 
   .season-end {
-    font-size: clamp(1.04rem, 5.5vw, 1.32rem);
-    padding: 1rem;
+    font-size: clamp(1.05rem, 5.5vw, 1.35rem);
+    padding: 1.1rem;
   }
 
   .league-modal {
@@ -673,6 +788,4 @@ summary:focus-visible,
     max-height: 95vh;
     padding: 1rem;
   }
-
-  .donation-actions { margin-top: 1rem; }
 }


### PR DESCRIPTION
### Motivation
- Restaurar exactamente la estética original (tipografías, colores, glow, sombras, fondos y estilo de botones/cards) sin introducir un rediseño nuevo.
- Aplicar ese mismo theme a toda la web para coherencia visual mientras se preserva TODO el contenido y la lógica existente.
- Tocar lo mínimo imprescindible en `index.html` y `styles.css` para volver al theme histórico y adaptar la sección Donaciones al mismo look.

### Description
- Actualicé `index.html` para cargar las tipografías originales (`Orbitron` + `Inter`) y apuntar al CSS restaurado (`styles.css?v=20260210-theme-original`).
- Reemplacé y restauré la base visual en `styles.css` (variables y reglas) para recuperar paleta neon azul/violeta, fondos, glow, sombras, botones y cards coherentes con el theme original. 
- Añadí/ajusté estilos específicos para la sección Donaciones (`.donation-*`) y para `sponsor-description` para que la presentación quede consistente con el theme sin alterar contenido ni estructura del sponsor. 
- La sección Donaciones contiene exactamente el texto solicitado y el botón principal con texto `DONAR` enlaza a `https://cafecito.app/sudakaleague` y abre en nueva pestaña, usando el estilo de botones principales del theme restaurado. 
- No se modificó `app.js` ni ninguna lógica JavaScript y no se tocaron textos, números, estados, fechas ni cupos; el layout visual mantiene 2 columnas en desktop y 1 columna en móvil vía media queries. 

### Testing
- Ejecuté `node --check app.js` y la comprobación devolvió OK. (éxito)
- Levanté un servidor local con `python3 -m http.server 4173` para servir los archivos y validar cambios estáticos (servidor iniciado correctamente). (éxito)
- Intenté generar una captura con Playwright para ver la página renderizada pero el Chromium del entorno falló con un `SIGSEGV`, por lo que no se pudo completar la captura automática; el fallo es de la plataforma, no del código. (falló por entorno)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a839f34f8833286b953a4cc7abd9d)