### PR TITLE
Restore solid dark-blue page background and remove retro texture overlays

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 :root {
-  --bg-main: #06060f;
+  --bg-main: #07122b;
   --bg-alt: #0d0b1d;
   --bg-surface: rgba(18, 16, 40, 0.88);
   --bg-surface-strong: rgba(12, 12, 29, 0.96);
@@ -27,11 +27,7 @@ body {
   font-size: 16px;
   line-height: 1.75;
   color: var(--text-main);
-  background:
-    radial-gradient(circle at 10% 0%, rgba(81, 237, 255, 0.2), transparent 38%),
-    radial-gradient(circle at 84% 6%, rgba(158, 96, 255, 0.24), transparent 42%),
-    radial-gradient(circle at 56% 86%, rgba(50, 34, 118, 0.38), transparent 46%),
-    linear-gradient(160deg, var(--bg-alt) 0%, #06070f 45%, #050509 100%);
+  background-color: var(--bg-main);
 }
 
 body.no-scroll { overflow: hidden; }
@@ -41,13 +37,7 @@ body.no-scroll { overflow: hidden; }
   inset: 0;
   z-index: -1;
   pointer-events: none;
-  opacity: 0.8;
-  mix-blend-mode: screen;
-  background-image:
-    linear-gradient(120deg, rgba(255, 255, 255, 0.035), transparent 28%),
-    repeating-linear-gradient(to bottom, rgba(255, 255, 255, 0.02) 0, rgba(255, 255, 255, 0.02) 1px, transparent 3px, transparent 6px),
-    radial-gradient(circle at 18% 26%, rgba(43, 214, 255, 0.18) 0 2px, transparent 2px),
-    radial-gradient(circle at 82% 72%, rgba(154, 122, 255, 0.2) 0 2px, transparent 2px);
+  display: none;
 }
 
 .section {


### PR DESCRIPTION
### Motivation
- Recuperar la estética original con un fondo azul oscuro liso y eliminar por completo las líneas/texturas/grillas retro que estaban aplicadas como overlay de fondo.

### Description
- Actualicé `styles.css`: cambié `--bg-main` a `#07122b`, reemplacé el `background` con `background-color: var(--bg-main)` en `body` y desactivé la capa visual retro `.bg-effects` estableciendo `display: none`, sin tocar HTML ni JS ni contenido.

### Testing
- Verifiqué con `rg`/búsqueda en `styles.css` que ya no haya `repeating-linear-gradient` ni `background-image` aplicados a la capa de fondo y la comprobación pasó.
- Inicié un servidor simple (`python3 -m http.server`) y confirmé con `curl -I http://127.0.0.1:4173/index.html` que el archivo se sirve correctamente (HTTP 200). 
- Intenté generar una captura con Playwright para validar visualmente el resultado pero el proceso de Chromium falló con un `SIGSEGV` en este entorno, por lo que la captura automática no se completó.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a8751720c833297be343ae3f20df1)