### PR TITLE
Separar tarjeta Copa Interdivisional y agregar cruces desplegables

### DIFF
--- a/app.js
+++ b/app.js
@@ -185,116 +185,48 @@ const PES6_HISTORY_META = {
   ]
 };
 
-const CUP_HISTORY_T23 = {
-  title: "T23 – Copa Interdivisional SLP",
-  rounds: [
-    {
-      name: "Octavos Playoff",
-      matches: [
-        {
-          label: "Octavo 1",
-          teamA: { club: "Lanús", player: "Edug98 (Primera)", shield: "/img/escudos/lanus.png" },
-          teamB: { club: "Argentinos", player: "Facualanis (Segunda)", shield: "/img/escudos/argentinos.png" }
-        },
-        {
-          label: "Octavo 2",
-          teamA: { club: "Millonarios", player: "Fafafa (Primera)", shield: "/img/escudos/millonarios.png" },
-          teamB: { club: "Cruzeiro", player: "Crislot26 (Segunda)", shield: "/img/escudos/cruzeiro.png" }
-        },
-        {
-          label: "Octavo 3",
-          teamA: { club: "Santos FC", player: "LombardoCABJ (Primera)", shield: "/img/escudos/santos_fc.png" },
-          teamB: { club: "Sao Paulo", player: "SoyLefo (Segunda)", shield: "/img/escudos/sao_paulo.png" }
-        },
-        {
-          label: "Octavo 4",
-          teamA: { club: "Estudiantes", player: "Exeeneta (Primera)", shield: "/img/escudos/estudiantes.png" },
-          teamB: { club: "Internacional SC", player: "Joser17 (Segunda)", shield: "/img/escudos/internacional_sc.png" }
-        },
-        {
-          label: "Octavo 5",
-          teamA: { club: "Peñarol", player: "TunTun (Primera)", shield: "/img/escudos/penarol.png" },
-          teamB: { club: "Huracán", player: "Leom (Tercera)", shield: "/img/escudos/huracan.png" }
-        },
-        {
-          label: "Octavo 6",
-          teamA: { club: "Nacional", player: "Aacuis09 (Primera)", shield: "/img/escudos/nacional.png" },
-          teamB: { club: "Peñarol", player: "Cacherinhooo (Tercera)", shield: "/img/escudos/penarol.png" }
-        },
-        {
-          label: "Octavo 7",
-          teamA: { club: "Colo Colo", player: "Broko (Primera)", shield: "/img/escudos/colo_colo.png" },
-          teamB: { club: "Internacional SC", player: "Gab0211 (Tercera)", shield: "/img/escudos/internacional_sc.png" }
-        },
-        {
-          label: "Octavo 8",
-          teamA: { club: "Argentinos JRS", player: "Ivanarocela (Primera)", shield: "/img/escudos/argentinos_jrs.png" },
-          teamB: { club: "Colo Colo", player: "Joelignacho (Segunda)", shield: "/img/escudos/colo_colo.png" }
-        }
-      ]
-    },
-    {
-      name: "Cuartos Playoff",
-      matches: [
-        {
-          label: "Cuarto 1",
-          teamA: { club: "Ganador Octavo 1", player: "Por definir", shield: "/img/escudos/ganador_octavo_1.png" },
-          teamB: { club: "Ganador Octavo 2", player: "Por definir", shield: "/img/escudos/ganador_octavo_2.png" }
-        },
-        {
-          label: "Cuarto 2",
-          teamA: { club: "Ganador Octavo 3", player: "Por definir", shield: "/img/escudos/ganador_octavo_3.png" },
-          teamB: { club: "Ganador Octavo 4", player: "Por definir", shield: "/img/escudos/ganador_octavo_4.png" }
-        },
-        {
-          label: "Cuarto 3",
-          teamA: { club: "Ganador Octavo 5", player: "Por definir", shield: "/img/escudos/ganador_octavo_5.png" },
-          teamB: { club: "Ganador Octavo 6", player: "Por definir", shield: "/img/escudos/ganador_octavo_6.png" }
-        },
-        {
-          label: "Cuarto 4",
-          teamA: { club: "Ganador Octavo 7", player: "Por definir", shield: "/img/escudos/ganador_octavo_7.png" },
-          teamB: { club: "Ganador Octavo 8", player: "Por definir", shield: "/img/escudos/ganador_octavo_8.png" }
-        }
-      ]
-    },
-    {
-      name: "Semis Playoff",
-      matches: [
-        {
-          label: "Semi 1",
-          teamA: { club: "Ganador Cuarto 1", player: "Por definir", shield: "/img/escudos/ganador_cuarto_1.png" },
-          teamB: { club: "Ganador Cuarto 2", player: "Por definir", shield: "/img/escudos/ganador_cuarto_2.png" }
-        },
-        {
-          label: "Semi 2",
-          teamA: { club: "Ganador Cuarto 3", player: "Por definir", shield: "/img/escudos/ganador_cuarto_3.png" },
-          teamB: { club: "Ganador Cuarto 4", player: "Por definir", shield: "/img/escudos/ganador_cuarto_4.png" }
-        }
-      ]
-    },
-    {
-      name: "Final Playoff",
-      matches: [
-        {
-          label: "Final Playoff",
-          teamA: { club: "Ganador Semi 1", player: "Por definir", shield: "/img/escudos/ganador_semi_1.png" },
-          teamB: { club: "Ganador Semi 2", player: "Por definir", shield: "/img/escudos/ganador_semi_2.png" }
-        }
-      ]
-    },
-    {
-      name: "Final Interdivisional",
-      matches: [
-        {
-          label: "Final Interdivisional",
-          teamA: { club: "Universitario", player: "H09", shield: "/img/escudos/universitario.png" },
-          teamB: { club: "Ganador Final Playoff", player: "Por definir", shield: "/img/escudos/ganador_final_playoff.png" }
-        }
-      ]
-    }
-  ]
-};
+const CUP_CROSSINGS_OCTAVOS = [
+  {
+    label: "Octavo 1",
+    teamA: { club: "Lanús", player: "Edug98", division: "Primera" },
+    teamB: { club: "Argentinos", player: "Facualanis", division: "Segunda" }
+  },
+  {
+    label: "Octavo 2",
+    teamA: { club: "Millonarios", player: "Fafafa", division: "Primera" },
+    teamB: { club: "Cruzeiro", player: "Crislot26", division: "Segunda" }
+  },
+  {
+    label: "Octavo 3",
+    teamA: { club: "Santos FC", player: "LombardoCABJ", division: "Primera" },
+    teamB: { club: "Sao Paulo", player: "SoyLefo", division: "Segunda" }
+  },
+  {
+    label: "Octavo 4",
+    teamA: { club: "Estudiantes", player: "Exeeneta", division: "Primera" },
+    teamB: { club: "Internacional SC", player: "Joser17", division: "Segunda" }
+  },
+  {
+    label: "Octavo 5",
+    teamA: { club: "Peñarol", player: "TunTun", division: "Primera" },
+    teamB: { club: "Huracán", player: "Leom", division: "Tercera" }
+  },
+  {
+    label: "Octavo 6",
+    teamA: { club: "Nacional", player: "Aacuis09", division: "Primera" },
+    teamB: { club: "Peñarol", player: "Cacherinhooo", division: "Tercera" }
+  },
+  {
+    label: "Octavo 7",
+    teamA: { club: "Colo Colo", player: "Broko", division: "Primera" },
+    teamB: { club: "Internacional SC", player: "Gab0211", division: "Tercera" }
+  },
+  {
+    label: "Octavo 8",
+    teamA: { club: "Argentinos JRS", player: "Ivanarocela", division: "Primera" },
+    teamB: { club: "Colo Colo", player: "Joelignacho", division: "Segunda" }
+  }
+];
 
 const overlay = document.getElementById("modal-overlay");
 const modals = [...document.querySelectorAll(".league-modal")];
@@ -307,6 +239,10 @@ const pes6Remaining = document.getElementById("pes6-remaining");
 const cupRemaining = document.getElementById("cup-remaining");
 const pes6SeasonName = document.getElementById("pes6SeasonName");
 const cupStatus = document.getElementById("cupStatus");
+const cupInterdivisionalCard = document.getElementById("cup-interdivisional-card");
+const cupCrossingsPanel = document.getElementById("cup-crossings-panel");
+const cupCrossingsList = document.getElementById("cup-crossings-list");
+const cupToggleLabel = document.getElementById("cup-toggle-label");
 const sfStatus = document.getElementById("sfStatus");
 const sfSeasonName = document.getElementById("sfSeasonName");
 const sfSeasonNote = document.getElementById("sfSeasonNote");
@@ -378,8 +314,8 @@ function updatePes6Remaining() {
 function updateCupRemaining() {
   updateCountdown(CUP_INTERDIVISIONAL_FINAL_TARGET, cupRemaining, {
     showHoursOnLastDay: true,
-    formatDays: (value) => `⏳ ${value} días restantes`,
-    formatHours: (value) => `⏳ ${value} horas restantes`
+    formatDays: (value) => `${value} días restantes`,
+    formatHours: (value) => `${value} horas restantes`
   });
 }
 
@@ -1211,33 +1147,14 @@ function createHistoryAccordionItem(seasonData, index) {
   return item;
 }
 
-function createCupTeamNode(team) {
-  const teamNode = document.createElement("article");
-  teamNode.className = "cup-team";
-
-  const shield = document.createElement("img");
-  shield.className = "cup-team-shield";
-  shield.src = team.shield;
-  shield.alt = `Escudo de ${team.club}`;
-  shield.loading = "lazy";
-
-  const info = document.createElement("div");
-  info.className = "cup-team-info";
-
-  const club = document.createElement("p");
-  club.className = "cup-team-club";
-  club.textContent = team.club;
-
-  const player = document.createElement("p");
-  player.className = "cup-team-player";
-  player.textContent = team.player;
-
-  info.append(club, player);
-  teamNode.append(shield, info);
-  return teamNode;
+function createCupCrossingTeamNode(teamData) {
+  const team = document.createElement("div");
+  team.className = "cup-crossing-team";
+  team.textContent = `${teamData.club} – ${teamData.player} – ${teamData.division}`;
+  return team;
 }
 
-function createCupMatchCard(matchData) {
+function createCupCrossingCard(matchData) {
   const card = document.createElement("article");
   card.className = "cup-match-card";
 
@@ -1246,59 +1163,72 @@ function createCupMatchCard(matchData) {
   label.textContent = matchData.label;
 
   const body = document.createElement("div");
-  body.className = "cup-match-body";
+  body.className = "cup-crossing-body";
 
-  const versus = document.createElement("span");
+  const versus = document.createElement("p");
   versus.className = "cup-match-versus";
   versus.textContent = "VS";
 
-  body.append(createCupTeamNode(matchData.teamA), versus, createCupTeamNode(matchData.teamB));
+  body.append(
+    createCupCrossingTeamNode(matchData.teamA),
+    versus,
+    createCupCrossingTeamNode(matchData.teamB)
+  );
+
   card.append(label, body);
   return card;
 }
 
-function createCupRoundSection(roundData) {
-  const section = document.createElement("section");
-  section.className = "cup-round-section";
+function renderCupCrossings() {
+  if (!cupCrossingsList) return;
+  cupCrossingsList.replaceChildren();
 
-  const heading = document.createElement("h4");
-  heading.className = "cup-round-title";
-  heading.textContent = roundData.name;
-
-  const matchesGrid = document.createElement("div");
-  matchesGrid.className = "cup-round-grid";
-
-  roundData.matches.forEach((match) => {
-    matchesGrid.appendChild(createCupMatchCard(match));
+  CUP_CROSSINGS_OCTAVOS.forEach((matchData) => {
+    cupCrossingsList.appendChild(createCupCrossingCard(matchData));
   });
-
-  section.append(heading, matchesGrid);
-  return section;
 }
 
-function renderCupHistory() {
-  const container = document.getElementById("pes6-cup-history");
-  if (!container) return;
+function setCupCrossingsExpanded(expanded) {
+  if (!cupInterdivisionalCard || !cupCrossingsPanel || !cupToggleLabel) return;
 
-  container.replaceChildren();
+  cupInterdivisionalCard.setAttribute("aria-expanded", String(expanded));
+  cupToggleLabel.textContent = expanded ? "Ocultar cruces" : "Ver cruces";
 
-  const wrapper = document.createElement("section");
-  wrapper.className = "cup-history-block";
+  if (expanded) {
+    cupCrossingsPanel.hidden = false;
+    cupCrossingsPanel.classList.add("is-open");
+    return;
+  }
 
-  const heading = document.createElement("h3");
-  heading.className = "cup-history-heading";
-  heading.textContent = "Historial de Copas";
+  cupCrossingsPanel.classList.remove("is-open");
 
-  const title = document.createElement("h4");
-  title.className = "cup-history-title";
-  title.textContent = CUP_HISTORY_T23.title;
+  const onTransitionEnd = () => {
+    if (!cupCrossingsPanel.classList.contains("is-open")) {
+      cupCrossingsPanel.hidden = true;
+    }
+    cupCrossingsPanel.removeEventListener("transitionend", onTransitionEnd);
+  };
 
-  wrapper.append(heading, title);
-  CUP_HISTORY_T23.rounds.forEach((round) => {
-    wrapper.appendChild(createCupRoundSection(round));
+  cupCrossingsPanel.addEventListener("transitionend", onTransitionEnd);
+}
+
+function setupCupCrossingsAccordion() {
+  if (!cupInterdivisionalCard || !cupCrossingsPanel) return;
+
+  renderCupCrossings();
+
+  const toggleCrossings = () => {
+    const isExpanded = cupInterdivisionalCard.getAttribute("aria-expanded") === "true";
+    setCupCrossingsExpanded(!isExpanded);
+  };
+
+  cupInterdivisionalCard.addEventListener("click", toggleCrossings);
+  cupInterdivisionalCard.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      toggleCrossings();
+    }
   });
-
-  container.appendChild(wrapper);
 }
 
 function renderPes6History() {
@@ -1306,8 +1236,6 @@ function renderPes6History() {
   if (!container) return;
 
   container.replaceChildren();
-
-  renderCupHistory();
 
   PES6_HISTORY.forEach((seasonData, index) => {
     container.appendChild(createHistoryAccordionItem(seasonData, index));
@@ -1318,6 +1246,7 @@ setupTabs();
 renderPalmares();
 renderPes6Ranking();
 renderPes6History();
+setupCupCrossingsAccordion();
 applyKofLeagueContent();
 applyWhatsAppLinks();
 updateSeasonStatus();

--- a/index.html
+++ b/index.html
@@ -45,16 +45,6 @@
           </div>
         </article>
 
-        <article class="season-card" aria-labelledby="cup-season-title">
-          <div class="season-card-header">
-            <h3 id="cup-season-title">Copa Interdivisional SLP</h3>
-            <span id="cupStatus" class="season-badge season-badge-active">ACTIVA</span>
-          </div>
-          <p class="season-title">Fase: Octavos</p>
-          <p class="season-note">Finalización de octavos: 13/02/2026</p>
-          <p class="season-countdown-label"><span class="season-end" id="cup-remaining">Calculando…</span></p>
-        </article>
-
         <article class="season-card" aria-labelledby="kof-season-title">
           <div class="season-card-header">
             <h3 id="kof-season-title">🥊 —</h3>
@@ -68,6 +58,23 @@
             <span id="sf-slots-badge" class="mini-badge">—</span>
           </div>
         </article>
+      </div>
+    </section>
+
+    <section class="section hud-separator cup-interdivisional-section" aria-labelledby="cup-season-title">
+      <article id="cup-interdivisional-card" class="season-card cup-interdivisional-card" role="button" tabindex="0" aria-expanded="false" aria-controls="cup-crossings-panel">
+        <div class="season-card-header">
+          <h3 id="cup-season-title">Copa Interdivisional SLP</h3>
+          <span id="cupStatus" class="season-badge season-badge-active">ACTIVA</span>
+        </div>
+        <p class="season-title">Fase: Octavos</p>
+        <p class="season-note">Finalización de octavos: 13/02/2026</p>
+        <p class="season-countdown-label"><span class="season-end" id="cup-remaining">Calculando…</span></p>
+        <p id="cup-toggle-label" class="cup-toggle-label">Ver cruces</p>
+      </article>
+
+      <div id="cup-crossings-panel" class="cup-crossings-panel" hidden>
+        <div id="cup-crossings-list" class="cup-round-grid" aria-live="polite"></div>
       </div>
     </section>
 
@@ -300,7 +307,6 @@ UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES
         </section>
 
         <section class="tab-panel" role="tabpanel" id="pes6-tab-history" aria-labelledby="pes6-tab-btn-history" hidden>
-          <div id="pes6-cup-history"></div>
           <div id="pes6-history" class="history-layout"></div>
         </section>
 

--- a/styles.css
+++ b/styles.css
@@ -518,6 +518,58 @@ summary:focus-visible,
 
 .pes6-ranking-list-wrap { display: grid; gap: 0.8rem; }
 
+
+.cup-interdivisional-section {
+  padding-top: 0;
+}
+
+.cup-interdivisional-card {
+  cursor: pointer;
+}
+
+.cup-toggle-label {
+  margin: 0;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--line);
+  font-family: "Orbitron", "Inter", sans-serif;
+  font-size: 0.82rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.cup-crossings-panel {
+  margin-top: 0.9rem;
+  padding: 0.95rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-alt);
+  overflow: hidden;
+  opacity: 0;
+  max-height: 0;
+  transition: max-height 260ms ease, opacity 220ms ease;
+}
+
+.cup-crossings-panel.is-open {
+  opacity: 1;
+  max-height: 2200px;
+}
+
+.cup-crossing-body {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.cup-crossing-team {
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 0.65rem;
+  padding: 0.55rem 0.65rem;
+  background: var(--surface-alt);
+  font-size: 0.86rem;
+  line-height: 1.35;
+}
+
 .pes6-ranking-row,
 .history-row {
   border: 1px solid var(--line);


### PR DESCRIPTION
### Motivation
- Separar la tarjeta de la `Copa Interdivisional SLP` fuera del bloque `ESTADO DE TEMPORADA` y exponer sus cruces sin modificar el palmarés/historial existente.  
- Mantener exactamente la apariencia y textos actuales del Historial y de la tarjeta (estado, fase, fecha, contador) mientras se agrega un comportamiento acordeón para móviles.  
- Mostrar los cruces de `Octavos` (formato Equipo – Usuario – División) sólo al expandir la tarjeta y evitar que los cruces aparezcan dentro del tab `Historial`.  
- Ajustar el contador para la copa a `13/02/2026 23:59` y mostrar únicamente “X días restantes” (en el último día mostrar horas restantes).  

### Description
- Moví la tarjeta de copa fuera de `ESTADO DE TEMPORADA` y añadí una sección independiente con `id=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b40bae4e48332b5b1e5cc55fcb677)