### PR TITLE
Actualizar tarjeta Copa Interdivisional (Octavos) — mostrar escudos y división abreviada

### DIFF
--- a/app.js
+++ b/app.js
@@ -228,6 +228,58 @@ const CUP_CROSSINGS_OCTAVOS = [
   }
 ];
 
+const CUP_CROSSING_DIVISION_SHORT = {
+  Primera: "1ra Div",
+  Segunda: "2da Div",
+  Tercera: "3ra Div",
+  Cuarta: "4ta Div"
+};
+
+const CUP_CROSSING_CLUB_LOGO_MAP = {
+  lanus: "/assets/lanus.png",
+  argentinos: "/assets/argentinos.png",
+  "argentinos jrs": "/assets/argentinos.png",
+  cruzeiro: "/assets/cruzeiro.png",
+  "santos fc": "/assets/santos.png",
+  "sao paulo": "/assets/saopaulo.png",
+  estudiantes: "/assets/estudiantes.png",
+  "internacional sc": "/assets/internacional_sc.png",
+  penarol: "/assets/penarol (1).png",
+  huracan: "/assets/huracan.png",
+  nacional: "/assets/nacional.png",
+  "colo colo": "/assets/colocolo.png"
+};
+
+function normalizeClubName(value = "") {
+  return value
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, " ");
+}
+
+function getCupCrossingDivisionLabel(division = "") {
+  return CUP_CROSSING_DIVISION_SHORT[division] || division;
+}
+
+function getCupCrossingTeamLogoPath(teamData) {
+  if (teamData.logo) {
+    return teamData.logo.startsWith("/") ? teamData.logo : `/${teamData.logo}`;
+  }
+
+  const normalizedClub = normalizeClubName(teamData.club);
+  if (CUP_CROSSING_CLUB_LOGO_MAP[normalizedClub]) {
+    return CUP_CROSSING_CLUB_LOGO_MAP[normalizedClub];
+  }
+
+  if (!normalizedClub) return "";
+
+  const assetName = normalizedClub.replace(/\s+/g, "_");
+  return `/assets/${assetName}.png`;
+}
+
 const overlay = document.getElementById("modal-overlay");
 const modals = [...document.querySelectorAll(".league-modal")];
 const triggers = [...document.querySelectorAll(".modal-trigger")];
@@ -1150,7 +1202,35 @@ function createHistoryAccordionItem(seasonData, index) {
 function createCupCrossingTeamNode(teamData) {
   const team = document.createElement("div");
   team.className = "cup-crossing-team";
-  team.textContent = `${teamData.club} – ${teamData.player} – ${teamData.division}`;
+
+  const logoPath = getCupCrossingTeamLogoPath(teamData);
+  if (logoPath) {
+    const shield = document.createElement("img");
+    shield.className = "cup-crossing-shield";
+    shield.src = logoPath;
+    shield.alt = `Escudo de ${teamData.club}`;
+    shield.loading = "lazy";
+    shield.decoding = "async";
+    shield.addEventListener("error", () => {
+      shield.style.display = "none";
+    });
+    team.appendChild(shield);
+  }
+
+  const content = document.createElement("div");
+  content.className = "cup-crossing-content";
+
+  const player = document.createElement("p");
+  player.className = "cup-crossing-player";
+  player.textContent = teamData.player;
+
+  const division = document.createElement("span");
+  division.className = "cup-crossing-division";
+  division.textContent = getCupCrossingDivisionLabel(teamData.division);
+
+  content.append(player, division);
+  team.appendChild(content);
+
   return team;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -566,8 +566,49 @@ summary:focus-visible,
   border-radius: 0.65rem;
   padding: 0.55rem 0.65rem;
   background: var(--surface-alt);
-  font-size: 0.86rem;
-  line-height: 1.35;
+  display: flex;
+  align-items: center;
+  gap: 0.62rem;
+  min-width: 0;
+}
+
+.cup-crossing-shield {
+  width: 42px;
+  height: 42px;
+  object-fit: contain;
+  border-radius: 0.65rem;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  padding: 0.2rem;
+  flex-shrink: 0;
+}
+
+.cup-crossing-content {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.cup-crossing-player {
+  margin: 0;
+  font-size: 0.98rem;
+  font-weight: 700;
+  line-height: 1.2;
+  word-break: break-word;
+}
+
+.cup-crossing-division {
+  font-size: 0.72rem;
+  line-height: 1;
+  padding: 0.24rem 0.4rem;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  color: var(--text-soft);
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  opacity: 0.82;
+  white-space: nowrap;
 }
 
 .pes6-ranking-row,


### PR DESCRIPTION
### Motivation

- Modernizar la presentación de los cruces de Octavos en la tarjeta "Copa Interdivisional SLP" para mostrar el escudo en lugar del nombre del club y dejar al jugador como dato principal, manteniendo el resto del diseño idéntico.
- Mostrar la división en el formato abreviado solicitado (`Primera -> 1ra Div`, `Segunda -> 2da Div`, `Tercera -> 3ra Div`, `Cuarta -> 4ta Div`) y garantizar tolerancia ante escudos faltantes.

### Description

- Reemplacé el render simple `Club – Jugador – División` por un layout horizontal con `img (escudo)` + `Jugador` + `badge` de división y mantuve el comportamiento del acordeón y demás estilos de la tarjeta intactos.
- Añadí en `app.js` resolución de escudos por prioridad: usar `team.logo` si existe, usar un `mapping` explícito a `/assets/...` para clubes conocidos, y fallback automático por nombre normalizado del club (`/assets/<club_normalizado>.png`), además de normalización de nombres y mapeo de divisiones cortas.
- Implementé un handler de error en el `<img>` para ocultarlo si la imagen no carga y así no romper la UI; en ese caso se muestra igualmente el jugador y la división.
- Añadí estilos en `styles.css` para `.cup-crossing-team`, `.cup-crossing-shield`, `.cup-crossing-player` y `.cup-crossing-division` (escudo ~42x42, `object-fit: contain`, badge pequeño, responsivo y apto para mobile).
- Archivos modificados: `app.js`, `styles.css`.

### Testing

- Ejecuté verificación de sintaxis JS con `node --check app.js` y la comprobación fue exitosa. 
- Levanté un servidor local con `python3 -m http.server 4173` y navegué a la página para validar visualmente la sección desplegada, sin errores críticos en consola del servidor.
- Automatización visual: tomé una captura en mobile (viewport 390x844) abriendo la tarjeta con Playwright y la sección quedó renderizada con escudos cuando estaban disponibles y con fallback silencioso cuando faltan; la prueba visual se completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b4ff636808332b0c6062cf27c4c87)