### PR TITLE
Globalizar Copa Interdivisional desde archivos de datos (sin localStorage)

### DIFF
--- a/data/interdivisional.js
+++ b/data/interdivisional.js
@@ -1,0 +1,64 @@
+window.INTERDIVISIONAL_ACTIVE_SEASON = {
+  // Cambiá acá la temporada activa
+  season: "T24",
+
+  // Cargá los cruces iniciales de Octavos + winner ("home" | "away" | null)
+  octavos: [
+    {
+      label: "Octavos Play-offs 1",
+      home: { club: "Lanús", player: "Edug98", division: "Primera" },
+      away: { club: "Argentinos", player: "Facualanis", division: "Segunda" },
+      winner: null
+    },
+    {
+      label: "Octavos Play-offs 2",
+      home: { club: "Millonarios", player: "Fafafa", division: "Primera" },
+      away: { club: "Cruzeiro", player: "Crislot26", division: "Segunda" },
+      winner: null
+    },
+    {
+      label: "Octavos Play-offs 3",
+      home: { club: "Santos FC", player: "LombardoCABJ", division: "Primera" },
+      away: { club: "Sao Paulo", player: "SoyLefo", division: "Segunda" },
+      winner: null
+    },
+    {
+      label: "Octavos Play-offs 4",
+      home: { club: "Estudiantes", player: "Exeeneta", division: "Primera" },
+      away: { club: "Internacional SC", player: "Joser17", division: "Segunda" },
+      winner: null
+    },
+    {
+      label: "Octavos Play-offs 5",
+      home: { club: "Peñarol", player: "TunTun", division: "Primera" },
+      away: { club: "Huracán", player: "Leom", division: "Tercera" },
+      winner: null
+    },
+    {
+      label: "Octavos Play-offs 6",
+      home: { club: "Nacional", player: "Aacuis09", division: "Primera" },
+      away: { club: "Peñarol", player: "Cacherinhooo", division: "Tercera" },
+      winner: null
+    },
+    {
+      label: "Octavos Play-offs 7",
+      home: { club: "Colo Colo", player: "Broko", division: "Primera" },
+      away: { club: "Internacional SC", player: "Gab0211", division: "Tercera" },
+      winner: null
+    },
+    {
+      label: "Octavos Play-offs 8",
+      home: { club: "Argentinos JRS", player: "Ivanarocela", division: "Primera" },
+      away: { club: "Colo Colo", player: "Joelignacho", division: "Segunda" },
+      winner: null
+    }
+  ],
+
+  // Solo cargá winners por fase. Los cruces se generan automáticamente.
+  winners: {
+    cuartos_playoffs: [],
+    semifinal_playoffs: [],
+    final_playoffs: [],
+    final_copa_interdivisional: []
+  }
+};

--- a/data/interdivisional_history.js
+++ b/data/interdivisional_history.js
@@ -1,0 +1,115 @@
+window.INTERDIVISIONAL_HISTORY_SEASONS = [
+  {
+    season: "T23",
+    status: "completed",
+    champion: "Larrierismo",
+    phases: {
+      octavos_playoffs: [
+        {
+          label: "Octavos Play-offs 1",
+          home: { club: "Lanús", player: "Edug98", division: "Primera" },
+          away: { club: "Argentinos", player: "Facualanis", division: "Segunda" },
+          winner: "home"
+        },
+        {
+          label: "Octavos Play-offs 2",
+          home: { club: "Millonarios", player: "Fafafa", division: "Primera" },
+          away: { club: "Cruzeiro", player: "Crislot26", division: "Segunda" },
+          winner: "away"
+        },
+        {
+          label: "Octavos Play-offs 3",
+          home: { club: "Santos FC", player: "LombardoCABJ", division: "Primera" },
+          away: { club: "Sao Paulo", player: "SoyLefo", division: "Segunda" },
+          winner: "home"
+        },
+        {
+          label: "Octavos Play-offs 4",
+          home: { club: "Estudiantes", player: "Exeeneta", division: "Primera" },
+          away: { club: "Internacional SC", player: "Joser17", division: "Segunda" },
+          winner: "away"
+        },
+        {
+          label: "Octavos Play-offs 5",
+          home: { club: "Peñarol", player: "TunTun", division: "Primera" },
+          away: { club: "Huracán", player: "Leom", division: "Tercera" },
+          winner: "away"
+        },
+        {
+          label: "Octavos Play-offs 6",
+          home: { club: "Nacional", player: "Aacuis09", division: "Primera" },
+          away: { club: "Peñarol", player: "Cacherinhooo", division: "Tercera" },
+          winner: "away"
+        },
+        {
+          label: "Octavos Play-offs 7",
+          home: { club: "Colo Colo", player: "Broko", division: "Primera" },
+          away: { club: "Internacional SC", player: "Gab0211", division: "Tercera" },
+          winner: "away"
+        },
+        {
+          label: "Octavos Play-offs 8",
+          home: { club: "Argentinos JRS", player: "Ivanarocela", division: "Primera" },
+          away: { club: "Colo Colo", player: "Joelignacho", division: "Segunda" },
+          winner: "away"
+        }
+      ],
+      cuartos_playoffs: [
+        {
+          label: "Cuartos de final Play-offs 1",
+          home: { club: "Lanús", player: "Edug98", division: "Primera" },
+          away: { club: "Cruzeiro", player: "Crislot26", division: "Segunda" },
+          winner: "away"
+        },
+        {
+          label: "Cuartos de final Play-offs 2",
+          home: { club: "Santos FC", player: "LombardoCABJ", division: "Primera" },
+          away: { club: "Internacional SC", player: "Joser17", division: "Segunda" },
+          winner: "home"
+        },
+        {
+          label: "Cuartos de final Play-offs 3",
+          home: { club: "Huracán", player: "Leom", division: "Tercera" },
+          away: { club: "Peñarol", player: "Cacherinhooo", division: "Tercera" },
+          winner: "away"
+        },
+        {
+          label: "Cuartos de final Play-offs 4",
+          home: { club: "Internacional SC", player: "Gab0211", division: "Tercera" },
+          away: { club: "Colo Colo", player: "Joelignacho", division: "Segunda" },
+          winner: "away"
+        }
+      ],
+      semifinal_playoffs: [
+        {
+          label: "Semifinal Play-offs 1",
+          home: { club: "Cruzeiro", player: "Crislot26", division: "Segunda" },
+          away: { club: "Santos FC", player: "LombardoCABJ", division: "Primera" },
+          winner: "away"
+        },
+        {
+          label: "Semifinal Play-offs 2",
+          home: { club: "Peñarol", player: "Cacherinhooo", division: "Tercera" },
+          away: { club: "Colo Colo", player: "Joelignacho", division: "Segunda" },
+          winner: "home"
+        }
+      ],
+      final_playoffs: [
+        {
+          label: "Final Play-offs 1",
+          home: { club: "Santos FC", player: "LombardoCABJ", division: "Primera" },
+          away: { club: "Peñarol", player: "Cacherinhooo", division: "Tercera" },
+          winner: "away"
+        }
+      ],
+      final_copa_interdivisional: [
+        {
+          label: "Final Copa Interdivisional 1",
+          home: { club: "Cruzeiro", player: "Crislot26", division: "Segunda" },
+          away: { club: "Lanús", player: "Larrierismo", division: "Primera" },
+          winner: "away"
+        }
+      ]
+    }
+  }
+];

--- a/index.html
+++ b/index.html
@@ -433,6 +433,8 @@ UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES
     Visitantes: <strong id="visitor-count">Cargando…</strong>
   </div>
 
+  <script src="data/interdivisional.js"></script>
+  <script src="data/interdivisional_history.js"></script>
   <script src="app.js"></script>
   <script>
     (function () {


### PR DESCRIPTION
### Motivation
- Permitir que la Copa Interdivisional sea global y editable únicamente desde el código (repo) sin depender de `localStorage` y con historial versionado en archivos de datos.
- Exponer un único punto editable para la temporada activa donde se cargan `season`, `octavos` y los `winner` por fase para que la UI genere los cruces siguientes automáticamente.

### Description
- Reemplacé la carga/guardado en `localStorage` por la lectura desde variables globales definidas en archivos de datos: `window.INTERDIVISIONAL_ACTIVE_SEASON` y `window.INTERDIVISIONAL_HISTORY_SEASONS` en `data/interdivisional.js` y `data/interdivisional_history.js` respectivamente, y adapté `app.js` para construir el estado a partir de estas fuentes.
- Añadí funciones en `app.js` para normalizar `winner` (`normalizeWinnerValue`), normalizar octavos (`normalizeActiveOctavos`), generar cruces siguientes desde ganadores (`createMatchesFromPreviousWinners` / `createNextPhaseMatchesFromWinners`) y construir el estado activo (`buildInterdivisionalActiveSeason` / `buildInterdivisionalStateFromDataFiles`).
- Eliminé la edición en UI (clic para marcar ganador) y la persistencia en cliente; la pestaña activa queda en solo lectura y los ganadores se pintan según el campo `winner` en los datos del repo, mientras que cuartos/semis/finales se generan automáticamente cuando la fase anterior tiene todos los `winner` completos.
- Actualicé `index.html` para cargar primero `data/interdivisional.js` y `data/interdivisional_history.js` antes de `app.js`, y agregué los dos archivos de ejemplo editables en `data/` con la estructura esperada por la UI (`season`, `octavos`, `winners`, historial T23+).

### Testing
- Ejecuté `node --check app.js` y la comprobación de sintaxis de `app.js` pasó correctamente.
- Serví la web con `python -m http.server 4173` y verifiqué la página en un navegador automatizado con Playwright, abriendo la tarjeta de la Copa Interdivisional y capturando una captura de pantalla (éxito y artefacto generado).
- Probé la generación automática de fases en la UI cargando los datos de `data/interdivisional.js` y `data/interdivisional_history.js` y verifiqué que Octavos se muestra siempre, los ganadores se resaltan y se desbloquean Cuartos/Semifinal/Final cuando corresponden (visual check con la captura).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b6039c2148332aca8fcf758d756f7)