### PR TITLE
Ajusta texto de temporada en card de Copa Interdivisional a T23

### DIFF
--- a/app.js
+++ b/app.js
@@ -1519,7 +1519,9 @@ function updateCupCardHeader() {
   const visiblePhases = getVisiblePhaseKeysForSeason(currentSeason);
   const activePhase = visiblePhases[visiblePhases.length - 1] || INTERDIVISIONAL_PHASES[0].key;
 
-  if (cupCurrentSeason) cupCurrentSeason.textContent = `Temporada ${currentSeason.season}`;
+  const displaySeason = currentSeason.season === "T24" ? "T23" : currentSeason.season;
+
+  if (cupCurrentSeason) cupCurrentSeason.textContent = `Temporada ${displaySeason}`;
   if (cupCurrentPhase) cupCurrentPhase.textContent = `Fase: ${getPhaseLabel(activePhase)}`;
 
   if (cupStatus) {

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
           <h3 id="cup-season-title">Copa Interdivisional SLP</h3>
           <span id="cupStatus" class="season-badge season-badge-active">ACTIVA</span>
         </div>
-        <p id="cup-current-season" class="season-title">Temporada T24</p>
+        <p id="cup-current-season" class="season-title">Temporada T23</p>
         <p id="cup-current-phase" class="season-note">Fase: Octavos Play-offs</p>
         <p class="season-countdown-label"><span class="season-end" id="cup-remaining">Calculando…</span></p>
         <p id="cup-toggle-label" class="cup-toggle-label">Ver cruces</p>


### PR DESCRIPTION
### Motivation
- Corregir la etiqueta visible de la card "Copa Interdivisional" para que muestre "T23" en lugar de "T24" sin tocar lógica, cruces, historial, fases ni estilos.

### Description
- Actualicé el texto estático del encabezado de la card en `index.html` de `Temporada T24` a `Temporada T23`.
- Ajusté el render dinámico en `app.js` para que, si la temporada activa viene como `T24`, el `displaySeason` en la card muestre `T23` (solo afecta al texto mostrado en la card).
- No se modificó la lógica de winners, brackets, fases ni los archivos de historial o datos (`data/interdivisional.json` / `data/interdivisional_history.js` permanecen intactos).
- Archivos modificados: `index.html`, `app.js`.

### Testing
- Ejecuté la verificación de sintaxis de JavaScript con `node --check app.js`, que completó sin errores.
- Inicié un servidor y generé una captura con Playwright para validar visualmente que la card muestra `Temporada T23`, y la captura confirma el cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b74b4a1488332bfe390b80bd9cc21)