### PR TITLE
Agregar cuadros de resultado por equipo en Copa Interdivisional (con soporte para penales)

### DIFF
--- a/data/interdivisional.js
+++ b/data/interdivisional.js
@@ -14,13 +14,15 @@ window.INTERDIVISIONAL_ACTIVE_SEASON = {
       label: "Octavos Play-offs 2",
       home: { club: "Millonarios", player: "Fafafa", division: "Primera" },
       away: { club: "Cruzeiro", player: "Crislot26", division: "Segunda" },
-      winner: null
+      winner: null,
+      result: { home: 2, away: 3 }
     },
     {
       label: "Octavos Play-offs 3",
       home: { club: "Santos FC", player: "LombardoCABJ", division: "Primera" },
       away: { club: "Sao Paulo", player: "SoyLefo", division: "Segunda" },
-      winner: "away"
+      winner: "away",
+      result: { home: 1, away: 1, pensHome: 3, pensAway: 4 }
     },
     {
       label: "Octavos Play-offs 4",

--- a/data/interdivisional.json
+++ b/data/interdivisional.json
@@ -8,107 +8,259 @@
         "octavos_playoffs": [
           {
             "label": "Octavos Play-offs 1",
-            "home": { "club": "Lanús", "player": "Edug98", "division": "Primera" },
-            "away": { "club": "Argentinos", "player": "Facualanis", "division": "Segunda" },
-            "winner": "home"
+            "home": {
+              "club": "Lanús",
+              "player": "Edug98",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Argentinos",
+              "player": "Facualanis",
+              "division": "Segunda"
+            },
+            "winner": "home",
+            "result": {
+              "home": 2,
+              "away": 0
+            }
           },
           {
             "label": "Octavos Play-offs 2",
-            "home": { "club": "Millonarios", "player": "Fafafa", "division": "Primera" },
-            "away": { "club": "Cruzeiro", "player": "Crislot26", "division": "Segunda" },
+            "home": {
+              "club": "Millonarios",
+              "player": "Fafafa",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Cruzeiro",
+              "player": "Crislot26",
+              "division": "Segunda"
+            },
             "winner": "away"
           },
           {
             "label": "Octavos Play-offs 3",
-            "home": { "club": "Santos FC", "player": "LombardoCABJ", "division": "Primera" },
-            "away": { "club": "Sao Paulo", "player": "SoyLefo", "division": "Segunda" },
+            "home": {
+              "club": "Santos FC",
+              "player": "LombardoCABJ",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Sao Paulo",
+              "player": "SoyLefo",
+              "division": "Segunda"
+            },
             "winner": "home"
           },
           {
             "label": "Octavos Play-offs 4",
-            "home": { "club": "Estudiantes", "player": "Exeeneta", "division": "Primera" },
-            "away": { "club": "Internacional SC", "player": "Joser17", "division": "Segunda" },
+            "home": {
+              "club": "Estudiantes",
+              "player": "Exeeneta",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Internacional SC",
+              "player": "Joser17",
+              "division": "Segunda"
+            },
             "winner": "away"
           },
           {
             "label": "Octavos Play-offs 5",
-            "home": { "club": "Peñarol", "player": "TunTun", "division": "Primera" },
-            "away": { "club": "Huracán", "player": "Leom", "division": "Tercera" },
+            "home": {
+              "club": "Peñarol",
+              "player": "TunTun",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Huracán",
+              "player": "Leom",
+              "division": "Tercera"
+            },
             "winner": "away"
           },
           {
             "label": "Octavos Play-offs 6",
-            "home": { "club": "Nacional", "player": "Aacuis09", "division": "Primera" },
-            "away": { "club": "Peñarol", "player": "Cacherinhooo", "division": "Tercera" },
+            "home": {
+              "club": "Nacional",
+              "player": "Aacuis09",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Peñarol",
+              "player": "Cacherinhooo",
+              "division": "Tercera"
+            },
             "winner": "away"
           },
           {
             "label": "Octavos Play-offs 7",
-            "home": { "club": "Colo Colo", "player": "Broko", "division": "Primera" },
-            "away": { "club": "Internacional SC", "player": "Gab0211", "division": "Tercera" },
+            "home": {
+              "club": "Colo Colo",
+              "player": "Broko",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Internacional SC",
+              "player": "Gab0211",
+              "division": "Tercera"
+            },
             "winner": "away"
           },
           {
             "label": "Octavos Play-offs 8",
-            "home": { "club": "Argentinos JRS", "player": "Ivanarocela", "division": "Primera" },
-            "away": { "club": "Colo Colo", "player": "Joelignacho", "division": "Segunda" },
+            "home": {
+              "club": "Argentinos JRS",
+              "player": "Ivanarocela",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Colo Colo",
+              "player": "Joelignacho",
+              "division": "Segunda"
+            },
             "winner": "away"
           }
         ],
         "cuartos_playoffs": [
           {
             "label": "Cuartos de final Play-offs 1",
-            "home": { "club": "Lanús", "player": "Edug98", "division": "Primera" },
-            "away": { "club": "Cruzeiro", "player": "Crislot26", "division": "Segunda" },
-            "winner": "away"
+            "home": {
+              "club": "Lanús",
+              "player": "Edug98",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Cruzeiro",
+              "player": "Crislot26",
+              "division": "Segunda"
+            },
+            "winner": "away",
+            "result": {
+              "home": 1,
+              "away": 1,
+              "pensHome": 4,
+              "pensAway": 5
+            }
           },
           {
             "label": "Cuartos de final Play-offs 2",
-            "home": { "club": "Santos FC", "player": "LombardoCABJ", "division": "Primera" },
-            "away": { "club": "Internacional SC", "player": "Joser17", "division": "Segunda" },
+            "home": {
+              "club": "Santos FC",
+              "player": "LombardoCABJ",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Internacional SC",
+              "player": "Joser17",
+              "division": "Segunda"
+            },
             "winner": "home"
           },
           {
             "label": "Cuartos de final Play-offs 3",
-            "home": { "club": "Huracán", "player": "Leom", "division": "Tercera" },
-            "away": { "club": "Peñarol", "player": "Cacherinhooo", "division": "Tercera" },
+            "home": {
+              "club": "Huracán",
+              "player": "Leom",
+              "division": "Tercera"
+            },
+            "away": {
+              "club": "Peñarol",
+              "player": "Cacherinhooo",
+              "division": "Tercera"
+            },
             "winner": "away"
           },
           {
             "label": "Cuartos de final Play-offs 4",
-            "home": { "club": "Internacional SC", "player": "Gab0211", "division": "Tercera" },
-            "away": { "club": "Colo Colo", "player": "Joelignacho", "division": "Segunda" },
+            "home": {
+              "club": "Internacional SC",
+              "player": "Gab0211",
+              "division": "Tercera"
+            },
+            "away": {
+              "club": "Colo Colo",
+              "player": "Joelignacho",
+              "division": "Segunda"
+            },
             "winner": "away"
           }
         ],
         "semifinal_playoffs": [
           {
             "label": "Semifinal Play-offs 1",
-            "home": { "club": "Cruzeiro", "player": "Crislot26", "division": "Segunda" },
-            "away": { "club": "Santos FC", "player": "LombardoCABJ", "division": "Primera" },
-            "winner": "away"
+            "home": {
+              "club": "Cruzeiro",
+              "player": "Crislot26",
+              "division": "Segunda"
+            },
+            "away": {
+              "club": "Santos FC",
+              "player": "LombardoCABJ",
+              "division": "Primera"
+            },
+            "winner": "away",
+            "result": {
+              "home": 0,
+              "away": 2
+            }
           },
           {
             "label": "Semifinal Play-offs 2",
-            "home": { "club": "Peñarol", "player": "Cacherinhooo", "division": "Tercera" },
-            "away": { "club": "Colo Colo", "player": "Joelignacho", "division": "Segunda" },
+            "home": {
+              "club": "Peñarol",
+              "player": "Cacherinhooo",
+              "division": "Tercera"
+            },
+            "away": {
+              "club": "Colo Colo",
+              "player": "Joelignacho",
+              "division": "Segunda"
+            },
             "winner": "home"
           }
         ],
         "final_playoffs": [
           {
             "label": "Final Play-offs 1",
-            "home": { "club": "Santos FC", "player": "LombardoCABJ", "division": "Primera" },
-            "away": { "club": "Peñarol", "player": "Cacherinhooo", "division": "Tercera" },
-            "winner": "away"
+            "home": {
+              "club": "Santos FC",
+              "player": "LombardoCABJ",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Peñarol",
+              "player": "Cacherinhooo",
+              "division": "Tercera"
+            },
+            "winner": "away",
+            "result": {
+              "home": 2,
+              "away": 2,
+              "pensHome": 2,
+              "pensAway": 4
+            }
           }
         ],
         "final_copa_interdivisional": [
           {
             "label": "Final Copa Interdivisional 1",
-            "home": { "club": "Cruzeiro", "player": "Crislot26", "division": "Segunda" },
-            "away": { "club": "Lanús", "player": "Larrierismo", "division": "Primera" },
-            "winner": "away"
+            "home": {
+              "club": "Cruzeiro",
+              "player": "Crislot26",
+              "division": "Segunda"
+            },
+            "away": {
+              "club": "Lanús",
+              "player": "Larrierismo",
+              "division": "Primera"
+            },
+            "winner": "away",
+            "result": {
+              "home": 1,
+              "away": 3
+            }
           }
         ]
       }
@@ -120,50 +272,124 @@
         "octavos_playoffs": [
           {
             "label": "Octavos Play-offs 1",
-            "home": { "club": "Lanús", "player": "Edug98", "division": "Primera" },
-            "away": { "club": "Argentinos", "player": "Facualanis", "division": "Segunda" },
+            "home": {
+              "club": "Lanús",
+              "player": "Edug98",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Argentinos",
+              "player": "Facualanis",
+              "division": "Segunda"
+            },
             "winner": null
           },
           {
             "label": "Octavos Play-offs 2",
-            "home": { "club": "Millonarios", "player": "Fafafa", "division": "Primera" },
-            "away": { "club": "Cruzeiro", "player": "Crislot26", "division": "Segunda" },
-            "winner": null
+            "home": {
+              "club": "Millonarios",
+              "player": "Fafafa",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Cruzeiro",
+              "player": "Crislot26",
+              "division": "Segunda"
+            },
+            "winner": null,
+            "result": {
+              "home": 2,
+              "away": 3
+            }
           },
           {
             "label": "Octavos Play-offs 3",
-            "home": { "club": "Santos FC", "player": "LombardoCABJ", "division": "Primera" },
-            "away": { "club": "Sao Paulo", "player": "SoyLefo", "division": "Segunda" },
-            "winner": null
+            "home": {
+              "club": "Santos FC",
+              "player": "LombardoCABJ",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Sao Paulo",
+              "player": "SoyLefo",
+              "division": "Segunda"
+            },
+            "winner": null,
+            "result": {
+              "home": 1,
+              "away": 1,
+              "pensHome": 3,
+              "pensAway": 4
+            }
           },
           {
             "label": "Octavos Play-offs 4",
-            "home": { "club": "Estudiantes", "player": "Exeeneta", "division": "Primera" },
-            "away": { "club": "Internacional SC", "player": "Joser17", "division": "Segunda" },
+            "home": {
+              "club": "Estudiantes",
+              "player": "Exeeneta",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Internacional SC",
+              "player": "Joser17",
+              "division": "Segunda"
+            },
             "winner": null
           },
           {
             "label": "Octavos Play-offs 5",
-            "home": { "club": "Peñarol", "player": "TunTun", "division": "Primera" },
-            "away": { "club": "Huracán", "player": "Leom", "division": "Tercera" },
+            "home": {
+              "club": "Peñarol",
+              "player": "TunTun",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Huracán",
+              "player": "Leom",
+              "division": "Tercera"
+            },
             "winner": null
           },
           {
             "label": "Octavos Play-offs 6",
-            "home": { "club": "Nacional", "player": "Aacuis09", "division": "Primera" },
-            "away": { "club": "Peñarol", "player": "Cacherinhooo", "division": "Tercera" },
+            "home": {
+              "club": "Nacional",
+              "player": "Aacuis09",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Peñarol",
+              "player": "Cacherinhooo",
+              "division": "Tercera"
+            },
             "winner": null
           },
           {
             "label": "Octavos Play-offs 7",
-            "home": { "club": "Colo Colo", "player": "Broko", "division": "Primera" },
-            "away": { "club": "Internacional SC", "player": "Gab0211", "division": "Tercera" },
+            "home": {
+              "club": "Colo Colo",
+              "player": "Broko",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Internacional SC",
+              "player": "Gab0211",
+              "division": "Tercera"
+            },
             "winner": null
           },
           {
             "label": "Octavos Play-offs 8",
-            "home": { "club": "Argentinos JRS", "player": "Ivanarocela", "division": "Primera" },
-            "away": { "club": "Colo Colo", "player": "Joelignacho", "division": "Segunda" },
+            "home": {
+              "club": "Argentinos JRS",
+              "player": "Ivanarocela",
+              "division": "Primera"
+            },
+            "away": {
+              "club": "Colo Colo",
+              "player": "Joelignacho",
+              "division": "Segunda"
+            },
             "winner": null
           }
         ],

--- a/data/interdivisional_history.js
+++ b/data/interdivisional_history.js
@@ -9,7 +9,8 @@ window.INTERDIVISIONAL_HISTORY_SEASONS = [
           label: "Octavos Play-offs 1",
           home: { club: "Lanús", player: "Edug98", division: "Primera" },
           away: { club: "Argentinos", player: "Facualanis", division: "Segunda" },
-          winner: "home"
+          winner: "home",
+          result: { home: 2, away: 0 }
         },
         {
           label: "Octavos Play-offs 2",
@@ -59,7 +60,8 @@ window.INTERDIVISIONAL_HISTORY_SEASONS = [
           label: "Cuartos de final Play-offs 1",
           home: { club: "Lanús", player: "Edug98", division: "Primera" },
           away: { club: "Cruzeiro", player: "Crislot26", division: "Segunda" },
-          winner: "away"
+          winner: "away",
+          result: { home: 1, away: 1, pensHome: 4, pensAway: 5 }
         },
         {
           label: "Cuartos de final Play-offs 2",
@@ -85,7 +87,8 @@ window.INTERDIVISIONAL_HISTORY_SEASONS = [
           label: "Semifinal Play-offs 1",
           home: { club: "Cruzeiro", player: "Crislot26", division: "Segunda" },
           away: { club: "Santos FC", player: "LombardoCABJ", division: "Primera" },
-          winner: "away"
+          winner: "away",
+          result: { home: 0, away: 2 }
         },
         {
           label: "Semifinal Play-offs 2",
@@ -99,7 +102,8 @@ window.INTERDIVISIONAL_HISTORY_SEASONS = [
           label: "Final Play-offs 1",
           home: { club: "Santos FC", player: "LombardoCABJ", division: "Primera" },
           away: { club: "Peñarol", player: "Cacherinhooo", division: "Tercera" },
-          winner: "away"
+          winner: "away",
+          result: { home: 2, away: 2, pensHome: 2, pensAway: 4 }
         }
       ],
       final_copa_interdivisional: [
@@ -107,7 +111,8 @@ window.INTERDIVISIONAL_HISTORY_SEASONS = [
           label: "Final Copa Interdivisional 1",
           home: { club: "Cruzeiro", player: "Crislot26", division: "Segunda" },
           away: { club: "Lanús", player: "Larrierismo", division: "Primera" },
-          winner: "away"
+          winner: "away",
+          result: { home: 1, away: 3 }
         }
       ]
     }

--- a/styles.css
+++ b/styles.css
@@ -695,6 +695,43 @@ summary:focus-visible,
   white-space: nowrap;
 }
 
+
+.cup-crossing-score {
+  margin-left: auto;
+  min-width: 3.25rem;
+  padding: 0.3rem 0.35rem;
+  border-radius: 0.55rem;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.1rem;
+  flex-shrink: 0;
+  text-align: center;
+}
+
+.cup-crossing-score.is-winner {
+  border-color: #2fbd6f;
+  background: color-mix(in srgb, #2fbd6f 18%, var(--surface));
+  box-shadow: 0 0 0 1px color-mix(in srgb, #2fbd6f 48%, transparent);
+}
+
+.cup-crossing-score-main {
+  font-size: 1.05rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.cup-crossing-score-pens {
+  font-size: 0.62rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text-soft);
+  letter-spacing: 0.02em;
+}
+
 .pes6-ranking-row,
 .history-row {
   border: 1px solid var(--line);


### PR DESCRIPTION
### Motivation
- Mostrar un cuadrito de resultado junto a cada equipo en los cruces de la Copa Interdivisional siguiendo la estructura de datos propuesta (`result` con `home`, `away`, `pensHome?`, `pensAway?`).
- Mantener que el campo `winner` sea la única fuente de verdad para el resaltado ganador, sin inferir ganador desde el marcador.

### Description
- Se agregó la normalización de resultados con la nueva función `normalizeMatchResult(result)` y se integró en el flujo de carga/normalización (`normalizeActiveOctavos`, `normalizeInterdivisionalState`, `createNextPhaseMatchesFromWinners`) para exponer `match.result` ya limpio. (`app.js`).
- Se añadió el render de un `score box` por equipo en `createCupCrossingTeamNode(...)` que muestra goles y, si aplica, la línea secundaria `(<pens>) PEN`; el resaltado del box usa exclusivamente el valor de `winner`. (`app.js`).
- Se añadieron estilos nuevos y compactos para el cuadro de resultado con clases `.cup-crossing-score`, `.cup-crossing-score-main` y `.cup-crossing-score-pens`. (`styles.css`).
- Se actualizaron ejemplos de datos en `data/interdivisional.js`, `data/interdivisional_history.js` y `data/interdivisional.json` para incluir casos de partidos normales y partidos definidos por penales y poder validar visualmente el comportamiento.

### Testing
- Se ejecutó `node --check app.js` y la verificación devolvió éxito. (OK)
- Se validó la sintaxis JSON con `python -m json.tool data/interdivisional.json > /dev/null` y la comprobación fue exitosa. (OK)
- Se levantó un servidor local y se generó una captura de la UI con Playwright para comprobar visualmente los `score box` y los casos con/sin penales; la captura se generó correctamente. (OK)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b9c60a7108332a7bd52293412a4b5)