### PR TITLE
Corrige Octavos Play-offs T24: SoyLefo 2–1, elimina penales y deja Play-offs 2 como pendiente

### DIFF
--- a/data/interdivisional.js
+++ b/data/interdivisional.js
@@ -14,15 +14,14 @@ window.INTERDIVISIONAL_ACTIVE_SEASON = {
       label: "Octavos Play-offs 2",
       home: { club: "Millonarios", player: "Fafafa", division: "Primera" },
       away: { club: "Cruzeiro", player: "Crislot26", division: "Segunda" },
-      winner: null,
-      result: { home: 2, away: 3 }
+      winner: null
     },
     {
       label: "Octavos Play-offs 3",
       home: { club: "Santos FC", player: "LombardoCABJ", division: "Primera" },
       away: { club: "Sao Paulo", player: "SoyLefo", division: "Segunda" },
       winner: "away",
-      result: { home: 1, away: 1, pensHome: 3, pensAway: 4 }
+      result: { home: 1, away: 2 }
     },
     {
       label: "Octavos Play-offs 4",

--- a/data/interdivisional.json
+++ b/data/interdivisional.json
@@ -296,11 +296,7 @@
               "player": "Crislot26",
               "division": "Segunda"
             },
-            "winner": null,
-            "result": {
-              "home": 2,
-              "away": 3
-            }
+            "winner": null
           },
           {
             "label": "Octavos Play-offs 3",
@@ -314,12 +310,10 @@
               "player": "SoyLefo",
               "division": "Segunda"
             },
-            "winner": null,
+            "winner": "away",
             "result": {
               "home": 1,
-              "away": 1,
-              "pensHome": 3,
-              "pensAway": 4
+              "away": 2
             }
           },
           {


### PR DESCRIPTION
### Motivation
- Corregir resultados erróneos en Octavos de la Copa Interdivisional para que la UI y los datos reflejen el partido real entre LombardoCABJ y SoyLefo como victoria en tiempo reglamentario por 1–2. 
- Quitar un resultado cargado por error en el cruce Fafafa vs Crislot26 y dejar ese partido como pendiente sin goles ni ganador.

### Description
- Actualicé `data/interdivisional.json` para eliminar el `result` de **Octavos Play-offs 2** y dejar `winner: null` para mostrar el partido como pendiente. 
- Reemplacé en `data/interdivisional.json` los campos de penales de **Octavos Play-offs 3** y dejé `result: { "home": 1, "away": 2 }` con `winner: "away"` para marcar a SoyLefo ganador en tiempo reglamentario. 
- Alineé los mismos cambios en `data/interdivisional.js` (temporada activa) para que la UI use los datos corregidos; los cambios afectan solo Octavos Play-offs 2 y 3.

### Testing
- Validé la sintaxis JSON con `python -m json.tool data/interdivisional.json` y la comprobación fue satisfactoria. 
- Levanté un servidor estático y verifiqué visualmente la página con un script de Playwright apuntando a `http://127.0.0.1:4173/index.html` y capturé una captura de pantalla como evidencia. 
- No se modificaron otras fases ni temporadas y las comprobaciones automáticas ejecutadas resultaron exitosas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ba4007d5c833297a227774fdc75a6)