### PR TITLE
Corregir resultados y validación de penales/partidos no jugados en carta PES6

### DIFF
--- a/data/interdivisional.json
+++ b/data/interdivisional.json
@@ -50,7 +50,11 @@
               "player": "SoyLefo",
               "division": "Segunda"
             },
-            "winner": "home"
+            "winner": "away",
+            "result": {
+              "home": 1,
+              "away": 2
+            }
           },
           {
             "label": "Octavos Play-offs 4",

--- a/data/interdivisional_history.js
+++ b/data/interdivisional_history.js
@@ -22,7 +22,8 @@ window.INTERDIVISIONAL_HISTORY_SEASONS = [
           label: "Octavos Play-offs 3",
           home: { club: "Santos FC", player: "LombardoCABJ", division: "Primera" },
           away: { club: "Sao Paulo", player: "SoyLefo", division: "Segunda" },
-          winner: "home"
+          winner: "away",
+          result: { home: 1, away: 2 }
         },
         {
           label: "Octavos Play-offs 4",


### PR DESCRIPTION
### Motivation
- Corregir un resultado incorrecto en el historial de la Copa Interdivisional (Octavos Play-offs 3) para reflejar la victoria real de SoyLefo 2–1 sin penales. 
- Evitar que partidos no jugados muestren goles, ganador resaltado o estado de finalizado en cualquier vista. 
- Aplicar una regla estricta de penales para que solo se muestren cuando el tiempo reglamentario sea empate. 
- Garantizar consistencia entre las vistas de `Cruces`, `Historial` y `Temporadas` para evitar discrepancias de datos.

### Description
- Se restringe la conservación de penales en `normalizeMatchResult` para que `pensHome/pensAway` solo se mantengan si `home === away` en el resultado. 
- Se añadieron `isMatchPlayed(match, seasonStatus)` y `normalizeMatchData(match, seasonStatus)` para validar explícitamente si un partido está jugado/finalizado y para limpiar partidos pendientes (`winner: null`, `result: null`). 
- Se integró la normalización central en `normalizeActiveOctavos` y `normalizeInterdivisionalState` para que todas las vistas usen la misma fuente validada. 
- Se modificó el render para que `createCupCrossingTeamNode` solo resalte al ganador y muestre goles/penales cuando `matchData.played === true`. 
- Se actualizó el dataset para mantener coherencia: `data/interdivisional.json` y `data/interdivisional_history.js` ahora muestran `Octavos Play-offs 3` como `winner: "away"` y `result: { home: 1, away: 2 }`.

### Testing
- Ejecutado `node --check app.js && node --check data/interdivisional.js && node --check data/interdivisional_history.js` y todos los chequeos pasaron correctamente. 
- Levantado servidor local con `python -m http.server 4173` para validar renderizado en contexto real y la página respondió correctamente. 
- Captura visual automatizada tomada con Playwright para verificar que la carta muestra el `1–2` de SoyLefo sin penales y que partidos pendientes aparecen sin marcador ni resaltado, y la captura se generó con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ba76c5f448332ae0665e563d147c8)