### PR TITLE
Rediseño visual integral oscuro + página de preview para Sudaka League

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,22 @@
   <meta name="description" content="Sudaka League - Comunidad de juegos retro online con formato competitivo." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&family=Orbitron:wght@600;700;800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&family=Rajdhani:wght@500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css?v=20260210-navy-minimal" />
 </head>
 <body>
   <div class="bg-effects" aria-hidden="true"></div>
+
+  <header class="topbar" aria-label="Barra superior de Sudaka League">
+    <div class="topbar-inner">
+      <a class="topbar-brand" href="#inicio" aria-label="Ir al inicio">
+        <!-- Placeholder de escudo Sudaka League: reemplazar por asset oficial si se agrega al repo -->
+        <span class="topbar-shield" aria-hidden="true">SL</span>
+        <span class="topbar-title">Sudaka League</span>
+      </a>
+      <a class="topbar-preview-link" href="preview.html">Preview</a>
+    </div>
+  </header>
 
   <header class="hero section" id="inicio">
     <p class="hero-kicker">Liga Oficial Retro Competitiva</p>
@@ -429,7 +440,7 @@ UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES
 
   <button id="back-to-top" class="btn btn-primary back-to-top" type="button" aria-label="Volver arriba">Volver arriba ↑</button>
 
-  <div id="visitor-counter" style="text-align:center; padding:16px 12px 28px; font-size:0.95rem; opacity:0.9;">
+  <div id="visitor-counter" class="visitor-counter">
     Visitantes: <strong id="visitor-count">Cargando…</strong>
   </div>
 

--- a/preview.html
+++ b/preview.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sudaka League - Preview de estilos</title>
+  <meta name="description" content="Preview interno de estilos visuales de Sudaka League." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&family=Rajdhani:wght@500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css?v=20260210-dark-competitive" />
+</head>
+<body>
+  <div class="bg-effects" aria-hidden="true"></div>
+
+  <header class="topbar" aria-label="Barra superior de Sudaka League">
+    <div class="topbar-inner">
+      <a class="topbar-brand" href="index.html" aria-label="Volver al inicio real">
+        <!-- Placeholder de escudo Sudaka League: reemplazar por asset oficial si se agrega al repo -->
+        <span class="topbar-shield" aria-hidden="true">SL</span>
+        <span class="topbar-title">Sudaka League</span>
+      </a>
+      <a class="topbar-preview-link" href="index.html">Volver</a>
+    </div>
+  </header>
+
+  <main class="preview-main">
+    <section class="panel-section">
+      <h1>Preview de estilo global</h1>
+      <p>Vista interna para revisar componentes visuales. No afecta contenido real de la web.</p>
+    </section>
+
+    <section class="preview-grid">
+      <article class="season-card">
+        <div class="season-card-header">
+          <h3>Botones</h3>
+          <span class="season-badge">Activo</span>
+        </div>
+        <div class="hero-actions" style="margin-top:0; justify-content:flex-start;">
+          <button class="btn btn-primary" type="button">Primario</button>
+          <button class="btn btn-secondary" type="button">Secundario</button>
+          <button class="btn btn-primary" type="button" disabled>Disabled</button>
+        </div>
+      </article>
+
+      <article class="season-card">
+        <div class="season-card-header">
+          <h3>Tarjetas</h3>
+          <span class="mini-badge">Demo</span>
+        </div>
+        <p class="season-note">Tarjeta estándar con fondo oscuro, borde sutil y jerarquía de texto clara.</p>
+        <p class="season-title">División principal - Temporada 24</p>
+      </article>
+    </section>
+
+    <section class="preview-grid">
+      <article class="preview-list">
+        <h2>Lista de temporadas</h2>
+        <div class="preview-item">Temporada 22 · Campeón: Silver</div>
+        <div class="preview-item">Temporada 23 · Campeón: Mica</div>
+        <div class="preview-item">Temporada 24 · En juego</div>
+      </article>
+
+      <article class="preview-matches">
+        <h2>Cruces</h2>
+        <div class="cup-crossing-team">
+          <p class="cup-crossing-player">Pendiente · Player A vs Player B</p>
+        </div>
+        <div class="cup-crossing-team">
+          <p class="cup-crossing-player">Jugado · Player C 2 - 1 Player D</p>
+        </div>
+        <div class="cup-crossing-team cup-crossing--winner">
+          <p class="cup-crossing-player">Ganador · Player E</p>
+        </div>
+      </article>
+    </section>
+
+    <section class="preview-modal-demo">
+      <article class="preview-modal-card">
+        <div class="season-card-header">
+          <h2 style="margin:0;">Modal / Cajón (demo abierto)</h2>
+          <button class="close-btn" type="button" aria-label="Cerrar demo">×</button>
+        </div>
+        <div class="tab-bar">
+          <button class="tab-btn is-active" type="button">Resumen</button>
+          <button class="tab-btn" type="button">Reglas</button>
+          <button class="tab-btn" type="button">Historial</button>
+        </div>
+        <p>Contenido de ejemplo para validar el tratamiento visual de overlays y paneles.</p>
+        <button class="btn btn-primary" type="button">Acción principal</button>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,40 +1,64 @@
 :root {
-  --bg-main: #061a34;
-  --surface: #0d2747;
-  --surface-alt: #103157;
-  --text-main: #f3f7ff;
-  --text-soft: #ced9e6;
-  --accent: #7fcfff;
-  --line: rgba(127, 207, 255, 0.35);
-  --line-strong: rgba(127, 207, 255, 0.65);
-  --radius-lg: 1rem;
-  --radius-md: 0.8rem;
-  --shadow-soft: 0 10px 24px rgba(0, 0, 0, 0.25);
+  --bg-main: #050b15;
+  --bg-elevated: #0a1323;
+  --bg-card: #0f1b2f;
+  --bg-card-strong: #15243a;
+  --text-main: #eef4ff;
+  --text-muted: #aebbcf;
+  --line: rgba(173, 191, 215, 0.18);
+  --line-strong: rgba(173, 191, 215, 0.34);
+  --accent: #58c9ff;
+  --accent-soft: rgba(88, 201, 255, 0.22);
+  --danger: #ff6f6f;
+  --radius-sm: 0.7rem;
+  --radius-md: 1rem;
+  --radius-lg: 1.3rem;
+  --shadow-soft: 0 14px 34px rgba(0, 0, 0, 0.34);
+  --shadow-card: 0 16px 26px rgba(0, 0, 0, 0.26);
+  --glow: 0 0 0 1px var(--accent-soft), 0 0 26px -10px var(--accent);
+  --max-width: min(1160px, 92%);
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
 
-html { scroll-behavior: smooth; }
+html {
+  scroll-behavior: smooth;
+}
 
 body {
   margin: 0;
   min-height: 100vh;
   overflow-x: hidden;
-  font-family: "Inter", system-ui, sans-serif;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
   font-size: 16px;
   line-height: 1.7;
   color: var(--text-main);
-  background: var(--bg-main);
+  background:
+    radial-gradient(1200px 560px at 50% -260px, rgba(88, 201, 255, 0.12), transparent 65%),
+    linear-gradient(180deg, #040913 0%, var(--bg-main) 42%, #060d18 100%);
 }
 
-body.no-scroll { overflow: hidden; }
+body.no-scroll {
+  overflow: hidden;
+}
 
-.bg-effects { display: none; }
+.bg-effects {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image: linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px), linear-gradient(90deg, rgba(255, 255, 255, 0.02) 1px, transparent 1px);
+  background-size: 80px 80px;
+  mask-image: radial-gradient(circle at 20% 0%, black, transparent 62%);
+  opacity: 0.42;
+}
 
 .section {
-  width: min(1180px, 92%);
+  width: var(--max-width);
   margin: 0 auto;
-  padding: clamp(4rem, 8vw, 6rem) 0;
+  padding: clamp(3rem, 8vw, 5rem) 0;
 }
 
 h1,
@@ -43,90 +67,201 @@ h3,
 .hero-kicker,
 .btn,
 .tab-btn,
-.season-badge {
-  font-family: "Orbitron", "Inter", sans-serif;
-  text-transform: uppercase;
+.cup-tab-btn,
+.season-badge,
+.topbar-title {
+  font-family: "Rajdhani", "Inter", sans-serif;
   letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3 {
+  margin-top: 0;
+  line-height: 1.2;
 }
 
 h2 {
-  margin: 0 0 2rem;
-  font-size: clamp(1.35rem, 2.9vw, 2rem);
-  line-height: 1.3;
+  margin-bottom: 1.7rem;
+  font-size: clamp(1.45rem, 3.8vw, 2.05rem);
 }
 
 p,
 li {
   margin-top: 0;
-  line-height: 1.7;
+}
+
+a {
+  color: var(--accent);
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  border-bottom: 1px solid var(--line);
+  backdrop-filter: blur(10px);
+  background: rgba(5, 11, 21, 0.85);
+}
+
+.topbar-inner {
+  width: var(--max-width);
+  margin: 0 auto;
+  min-height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.topbar-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.topbar-shield {
+  width: 34px;
+  height: 34px;
+  border-radius: 0.65rem;
+  display: grid;
+  place-items: center;
+  font-family: "Rajdhani", sans-serif;
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--text-main);
+  border: 1px solid var(--line-strong);
+  background: linear-gradient(160deg, #1a2b44, #101c2f);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.topbar-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.topbar-preview-link {
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  padding: 0.35rem 0.8rem;
+  color: var(--text-main);
+  text-decoration: none;
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
 .hero {
   text-align: center;
-  padding-top: clamp(5rem, 9vw, 7.5rem);
+  padding-top: clamp(4rem, 9vw, 6.6rem);
 }
 
 .hero-kicker {
   margin: 0;
-  color: var(--text-soft);
-  font-size: 0.84rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
 }
 
 .hero h1 {
-  margin: 1.4rem 0 1rem;
-  font-size: clamp(2.9rem, 11vw, 6.6rem);
-  line-height: 0.95;
+  margin: 1rem 0 0.9rem;
+  font-size: clamp(2.6rem, 10.8vw, 6rem);
 }
 
 .subtitle,
 .hero-copy {
   margin-inline: auto;
-  color: var(--text-soft);
+  color: var(--text-muted);
   max-width: 70ch;
 }
 
 .subtitle {
-  margin-bottom: 1.2rem;
+  margin-bottom: 1rem;
   font-weight: 700;
 }
 
 .hero-actions {
-  margin-top: 2.2rem;
+  margin-top: 2rem;
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 0.9rem;
+}
+
+.btn,
+.sponsor-cta,
+.pes6-ranking-toggle,
+.history-accordion-trigger,
+.cup-tab-btn,
+.tab-btn,
+.close-btn {
+  transition: border-color 180ms ease, box-shadow 180ms ease, background-color 180ms ease, transform 180ms ease;
 }
 
 .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  min-height: 48px;
+  padding: 0.8rem 1.3rem;
+  border-radius: 0.9rem;
   border: 1px solid var(--line-strong);
-  border-radius: 0.85rem;
-  min-height: 52px;
-  padding: 0.9rem 1.4rem;
-  font-size: 0.86rem;
-  font-weight: 800;
+  background: linear-gradient(180deg, #16253a, #0f1a2c);
+  color: var(--text-main);
   text-decoration: none;
-  color: #052035;
-  background: var(--accent);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
   box-shadow: var(--shadow-soft);
   cursor: pointer;
-  transition: opacity 160ms ease;
 }
 
-.btn-primary,
+.btn-primary {
+  border-color: rgba(88, 201, 255, 0.4);
+  background: linear-gradient(180deg, #173148, #11243a);
+}
+
 .btn-secondary {
-  color: #052035;
-  border-color: var(--accent);
-  background: var(--accent);
+  background: linear-gradient(180deg, #141f31, #0f1828);
 }
 
 .btn:hover,
 .btn:focus-visible,
+.btn:active,
+.sponsor-cta:hover,
+.sponsor-cta:focus-visible,
+.sponsor-cta:active,
 .tab-btn:hover,
 .tab-btn:focus-visible,
-.league-card:hover,
-.season-card:hover {
-  opacity: 0.92;
+.tab-btn:active,
+.cup-tab-btn:hover,
+.cup-tab-btn:focus-visible,
+.cup-tab-btn:active,
+.pes6-ranking-toggle:hover,
+.pes6-ranking-toggle:focus-visible,
+.history-accordion-trigger:hover,
+.history-accordion-trigger:focus-visible,
+.close-btn:hover,
+.close-btn:focus-visible {
+  border-color: rgba(88, 201, 255, 0.74);
+  box-shadow: var(--glow);
+}
+
+.btn:active,
+.tab-btn:active,
+.cup-tab-btn:active {
+  transform: translateY(1px);
+}
+
+.btn[disabled],
+.btn:disabled {
+  opacity: 0.46;
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
 .btn:focus-visible,
@@ -134,8 +269,10 @@ li {
 .system-panel-trigger:focus-visible,
 summary:focus-visible,
 .close-btn:focus-visible,
-.tab-btn:focus-visible {
-  outline: 2px solid var(--accent);
+.tab-btn:focus-visible,
+.cup-tab-btn:focus-visible,
+.topbar-preview-link:focus-visible {
+  outline: 2px solid rgba(88, 201, 255, 0.45);
   outline-offset: 2px;
 }
 
@@ -150,7 +287,7 @@ summary:focus-visible,
   right: 6%;
   bottom: -0.45rem;
   height: 1px;
-  background: var(--line);
+  background: linear-gradient(90deg, transparent, var(--line), transparent);
 }
 
 .panel-section,
@@ -161,65 +298,86 @@ summary:focus-visible,
 .palmares-block,
 .pes6-ranking,
 .season-status,
-.about-section {
+.about-section,
+.cup-crossings-panel {
   border: 1px solid var(--line);
   border-radius: var(--radius-lg);
-  background: var(--surface);
-  box-shadow: var(--shadow-soft);
+  background: linear-gradient(180deg, rgba(22, 33, 51, 0.95), rgba(13, 22, 35, 0.95));
+  box-shadow: var(--shadow-card);
 }
 
-.season-status {
-  padding: clamp(2.2rem, 5vw, 3rem);
-}
-
-.season-status h2 {
-  margin-bottom: 2rem;
+.season-status,
+.panel-section,
+.faq,
+.about-section {
+  padding: clamp(1.4rem, 5vw, 2.5rem);
 }
 
 .season-grid,
-.league-grid {
+.league-grid,
+.history-layout,
+.palmares-layout,
+.palmares-grid,
+.pes6-ranking-list-wrap,
+.cup-interdivisional-rounds,
+.cup-crossing-body {
   display: grid;
-  gap: clamp(1.2rem, 2.5vw, 1.8rem);
+  gap: 0.95rem;
 }
 
 .season-card {
-  padding: clamp(1.4rem, 3vw, 2rem);
+  padding: clamp(1.1rem, 3vw, 1.7rem);
+  background: linear-gradient(180deg, rgba(26, 40, 62, 0.88), rgba(14, 24, 39, 0.92));
 }
 
 .season-card-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  gap: 0.8rem;
+  margin-bottom: 0.8rem;
 }
 
 .season-card h3 {
   margin: 0;
-  font-size: clamp(1rem, 2vw, 1.2rem);
+  font-size: clamp(0.98rem, 2.4vw, 1.12rem);
 }
 
 .season-title,
-.season-note {
-  margin-bottom: 1.1rem;
-  color: var(--text-soft);
+.season-note,
+.system-panel-hint,
+.panel-section p,
+.panel-section li,
+.faq p,
+.about-section p,
+.donation-copy,
+.sponsor-description,
+.league-card-content p,
+.highlight-text,
+.note-text,
+.cup-match-label,
+.cup-team-player,
+.history-value.is-pending,
+.history-pending-badge,
+.donation-transfer-note {
+  color: var(--text-muted);
 }
 
 .season-countdown-label {
-  margin: 1rem 0 1.4rem;
+  margin: 0.9rem 0 1rem;
 }
 
 .season-end {
   display: block;
   width: 100%;
-  border: 1px solid var(--line);
-  border-radius: 0.9rem;
-  padding: 1.2rem 1rem;
-  font-family: "Orbitron", "Inter", sans-serif;
-  font-size: clamp(1.2rem, 3.2vw, 1.7rem);
+  border: 1px solid var(--line-strong);
+  border-radius: 0.8rem;
+  padding: 0.9rem;
   text-align: center;
+  font-family: "Rajdhani", sans-serif;
+  font-size: clamp(1rem, 4.5vw, 1.45rem);
   letter-spacing: 0.05em;
-  background: var(--surface-alt);
+  background: var(--bg-card-strong);
 }
 
 .season-badge,
@@ -228,40 +386,28 @@ summary:focus-visible,
   align-items: center;
   justify-content: center;
   border-radius: 999px;
-  border: 1px solid transparent;
+  border: 1px solid var(--line-strong);
   font-size: 0.72rem;
-  letter-spacing: 0.05em;
-  font-weight: 700;
+  line-height: 1;
   white-space: nowrap;
 }
 
 .season-badge {
-  padding: 0.34rem 0.72rem;
-  color: #052035;
-  border-color: var(--accent);
-  background: var(--accent);
-}
-
-.season-badge-active,
-.season-badge-wait,
-.season-badge-ended {
-  color: #052035;
-  border-color: var(--accent);
-  background: var(--accent);
+  padding: 0.38rem 0.7rem;
+  color: var(--text-main);
+  background: rgba(88, 201, 255, 0.08);
 }
 
 .season-slots {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.7rem;
-  margin-top: 0.5rem;
-  padding-top: 0.9rem;
+  gap: 0.6rem;
+  margin-top: 0.4rem;
+  padding-top: 0.8rem;
   border-top: 1px solid var(--line);
-  color: var(--text-soft);
+  color: var(--text-muted);
 }
-
-.season-slots-label { font-weight: 600; }
 
 .season-slots-value {
   color: var(--text-main);
@@ -271,10 +417,8 @@ summary:focus-visible,
 .mini-badge,
 .mini-badge--open,
 .mini-badge--closed {
-  padding: 0.24rem 0.62rem;
-  border-color: var(--line-strong);
-  background: var(--surface-alt);
-  color: var(--text-main);
+  padding: 0.24rem 0.55rem;
+  background: var(--bg-card-strong);
 }
 
 .league-card {
@@ -282,52 +426,47 @@ summary:focus-visible,
   cursor: pointer;
 }
 
+.league-card:hover,
+.league-card:focus-visible,
+.season-card:hover,
+.system-panel-trigger:hover,
+.sponsor-card:hover,
+.sponsor-card:focus-visible {
+  border-color: rgba(88, 201, 255, 0.52);
+  box-shadow: var(--shadow-card), var(--glow);
+}
+
 .league-card-banner,
 .modal-banner {
   width: 100%;
-  height: clamp(300px, 34vw, 340px);
-  display: block;
+  height: clamp(230px, 33vw, 330px);
   object-fit: cover;
   object-position: center;
+  display: block;
 }
 
 .league-card-content {
-  padding: 2rem;
+  padding: 1.4rem;
 }
 
 .league-card-content h3 {
-  margin: 0 0 1rem;
-  font-size: clamp(1.06rem, 2.2vw, 1.3rem);
-}
-
-.league-card-content p {
-  margin: 0;
-  color: var(--text-soft);
-  line-height: 1.75;
-  max-width: 60ch;
+  margin: 0 0 0.75rem;
+  font-size: clamp(1rem, 2.5vw, 1.25rem);
 }
 
 .sponsor-card {
   display: block;
-  text-decoration: none;
   color: inherit;
+  text-decoration: none;
 }
 
 .sponsor-card .league-card-content {
   display: grid;
-  gap: 0.9rem;
-}
-
-.sponsor-description {
-  margin: 0;
-  color: var(--text-soft);
-  line-height: 1.75;
-  text-transform: none;
-  letter-spacing: normal;
+  gap: 0.75rem;
 }
 
 .sponsor-description + .sponsor-description {
-  margin-top: 0.9rem;
+  margin-top: 0.6rem;
 }
 
 .sponsor-cta {
@@ -335,104 +474,80 @@ summary:focus-visible,
   width: fit-content;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--accent);
-  border-radius: 0.85rem;
   min-height: 44px;
-  padding: 0.65rem 1.1rem;
-  font-size: 0.84rem;
-  font-weight: 800;
-  color: #052035;
-  background: var(--accent);
+  padding: 0.6rem 1rem;
+  border-radius: 0.8rem;
+  border: 1px solid var(--line-strong);
+  background: linear-gradient(180deg, #16253a, #0f1a2c);
+  color: var(--text-main);
+  font-family: "Rajdhani", sans-serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
-.panel-section,
-.faq,
-.about-section {
-  padding: clamp(2.2rem, 5vw, 3rem);
+.system-panel-trigger {
+  cursor: pointer;
 }
-
-.panel-section p,
-.panel-section li,
-.faq p,
-.about-section p {
-  color: var(--text-soft);
-  max-width: 70ch;
-}
-
-.system-panel-trigger { cursor: pointer; }
 
 .system-panel-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 0.7rem;
-  margin-bottom: 0.65rem;
-}
-
-.system-panel-hint {
-  margin-bottom: 0.9rem;
-  color: var(--text-soft);
-  font-weight: 600;
+  gap: 0.8rem;
+  margin-bottom: 0.7rem;
 }
 
 .system-panel-indicator {
-  font-size: 1.25rem;
-  color: var(--text-soft);
+  font-size: 1.15rem;
+  color: var(--text-muted);
 }
 
 .faq details {
   border: 1px solid var(--line);
   border-radius: var(--radius-md);
-  background: var(--surface-alt);
-  padding: 1.2rem 1.3rem;
-  margin-bottom: 1rem;
+  background: var(--bg-card-strong);
+  padding: 1rem;
+  margin-bottom: 0.7rem;
 }
-
-.faq details[open] { padding-bottom: 1.3rem; }
 
 .faq summary {
   cursor: pointer;
   font-weight: 700;
-  color: var(--text-main);
 }
 
 .faq details p {
-  margin: 0.9rem 0 0;
-  padding-top: 0.5rem;
-  color: var(--text-soft);
-  line-height: 1.75;
+  margin: 0.8rem 0 0;
 }
 
-.about-section p { margin: 0.9rem 0 0; }
-
-.donations-section h2 { text-transform: none; }
+.donations-section h2 {
+  text-transform: none;
+}
 
 .donation-copy {
   white-space: pre-line;
-  color: var(--text-soft);
   margin-bottom: 0;
 }
 
 .donation-goal {
   display: grid;
-  gap: 0.62rem;
-  margin-top: 1.2rem;
+  gap: 0.55rem;
+  margin-top: 1rem;
 }
 
 .donation-goal-text {
   margin: 0;
-  font-family: "Orbitron", "Inter", sans-serif;
+  font-family: "Rajdhani", sans-serif;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--text-main);
 }
 
 .donation-goal-track {
   width: 100%;
+  height: 13px;
   border-radius: 999px;
   border: 1px solid var(--line-strong);
-  background: var(--surface-alt);
-  height: 14px;
+  background: var(--bg-card-strong);
   overflow: hidden;
 }
 
@@ -440,66 +555,47 @@ summary:focus-visible,
   display: block;
   width: 0;
   height: 100%;
-  background: var(--accent);
+  background: linear-gradient(90deg, rgba(88, 201, 255, 0.48), var(--accent));
 }
 
 .donation-actions {
-  margin-top: 1.2rem;
+  margin-top: 1rem;
   justify-content: flex-start;
 }
 
-.donation-transfer-card {
-  margin-top: 1.2rem;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-md);
-  background: var(--surface-alt);
-  padding: 1rem;
-}
-
-.donation-transfer-card h3 {
-  margin: 0 0 0.72rem;
-  font-size: clamp(1rem, 2.1vw, 1.14rem);
-}
-
-.donation-transfer-item { margin: 0.2rem 0; }
-
-.donation-transfer-note {
-  margin: 0.75rem 0 0;
-  color: var(--text-soft);
-}
-
-.note-text {
-  color: var(--text-soft);
-  font-style: italic;
-}
-
-.history-layout,
-.palmares-layout {
-  display: grid;
-  gap: 1rem;
-}
-
+.donation-transfer-card,
 .palmares-block,
 .pes6-ranking,
 .system-card,
 .history-section,
-.history-accordion-item {
-  padding: 1rem;
+.history-accordion-item,
+.cup-round-section,
+.cup-match-card {
+  border: 1px solid var(--line);
   border-radius: var(--radius-md);
-  border: 1px solid var(--line);
-  background: var(--surface-alt);
+  background: var(--bg-card-strong);
+  padding: 0.95rem;
 }
 
-.palmares-grid {
-  display: grid;
-  gap: 0.8rem;
+.donation-transfer-card {
+  margin-top: 1rem;
 }
 
-.palmares-card {
+.donation-transfer-card h3 {
+  margin: 0 0 0.6rem;
+}
+
+.donation-transfer-item {
+  margin: 0.2rem 0;
+}
+
+.palmares-card,
+.pes6-ranking-row,
+.history-row {
   border: 1px solid var(--line);
-  border-radius: 0.85rem;
-  padding: 0.85rem;
-  background: var(--surface);
+  border-radius: 0.75rem;
+  background: rgba(9, 16, 28, 0.7);
+  padding: 0.75rem;
 }
 
 .palmares-trophy,
@@ -510,14 +606,12 @@ summary:focus-visible,
 }
 
 .palmares-subtitle,
-.pes6-ranking-subtitle {
-  margin: 0 0 0.75rem;
-  color: var(--text-main);
-  font-weight: 700;
+.pes6-ranking-subtitle,
+.cup-history-heading,
+.cup-history-title,
+.cup-round-title {
+  margin: 0 0 0.7rem;
 }
-
-.pes6-ranking-list-wrap { display: grid; gap: 0.8rem; }
-
 
 .cup-interdivisional-section {
   padding-top: 0;
@@ -529,51 +623,53 @@ summary:focus-visible,
 
 .cup-toggle-label {
   margin: 0;
-  padding-top: 0.8rem;
+  padding-top: 0.7rem;
   border-top: 1px solid var(--line);
-  font-family: "Orbitron", "Inter", sans-serif;
-  font-size: 0.82rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
   color: var(--accent);
+  font-size: 0.78rem;
 }
 
 .cup-crossings-panel {
-  margin-top: 0.9rem;
-  padding: 0.95rem;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-md);
-  background: var(--surface-alt);
+  margin-top: 0.8rem;
+  padding: 0.9rem;
   overflow: hidden;
   opacity: 0;
   max-height: 0;
-  transition: max-height 260ms ease, opacity 220ms ease;
+  transition: max-height 280ms ease, opacity 220ms ease;
 }
 
 .cup-crossings-panel.is-open {
   opacity: 1;
-  max-height: 2200px;
+  max-height: 2600px;
+}
+
+.cup-card-tabs,
+.tab-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
 }
 
 .cup-card-tabs {
-  display: flex;
-  gap: 0.6rem;
-  margin-bottom: 0.85rem;
-  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
 }
 
-.cup-tab-btn {
-  border: 1px solid var(--line-strong);
-  border-radius: 999px;
-  background: var(--surface);
+.cup-tab-btn,
+.tab-btn {
+  border: 1px solid var(--line);
+  border-radius: 0.75rem;
+  background: rgba(11, 20, 33, 0.82);
   color: var(--text-main);
   font-weight: 700;
-  padding: 0.38rem 0.8rem;
+  font-size: 0.74rem;
+  padding: 0.48rem 0.72rem;
   cursor: pointer;
 }
 
-.cup-tab-btn.is-active {
-  background: color-mix(in srgb, var(--line-strong) 24%, var(--surface));
+.cup-tab-btn.is-active,
+.tab-btn.is-active {
+  border-color: rgba(88, 201, 255, 0.72);
+  background: rgba(88, 201, 255, 0.14);
 }
 
 .cup-tab-panel {
@@ -586,162 +682,131 @@ summary:focus-visible,
 
 .cup-history-toolbar {
   display: flex;
-  gap: 0.5rem;
   align-items: center;
-  margin-bottom: 0.85rem;
+  gap: 0.5rem;
+  margin-bottom: 0.8rem;
+}
+
+.cup-history-toolbar select,
+.copy-box textarea {
+  width: 100%;
+  border: 1px solid var(--line-strong);
+  border-radius: 0.75rem;
+  background: rgba(7, 14, 25, 0.82);
+  color: var(--text-main);
+  padding: 0.55rem 0.65rem;
 }
 
 .cup-history-toolbar select {
+  max-width: 220px;
+}
+
+.cup-crossing-team,
+.cup-team-shield,
+.cup-crossing-shield,
+.cup-crossing-score,
+.cup-crossing-division {
   border: 1px solid var(--line);
-  border-radius: 0.7rem;
-  background: var(--surface);
-  color: var(--text-main);
-  padding: 0.38rem 0.55rem;
-}
-
-.cup-interdivisional-rounds {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.cup-crossing-body {
-  display: grid;
-  gap: 0.55rem;
+  background: rgba(10, 17, 29, 0.9);
 }
 
 .cup-crossing-team {
   margin: 0;
-  border: 1px solid var(--line);
   border-radius: 0.65rem;
-  padding: 0.55rem 0.65rem;
-  background: var(--surface-alt);
+  padding: 0.5rem 0.6rem;
   display: flex;
   align-items: center;
-  gap: 0.62rem;
+  gap: 0.58rem;
   min-width: 0;
 }
 
 .cup-crossing-team.is-selectable {
   cursor: pointer;
-  transition: transform 120ms ease, border-color 120ms ease;
   text-align: left;
   color: inherit;
 }
 
 .cup-crossing-team.is-selectable:hover {
-  transform: translateY(-1px);
-  border-color: var(--line-strong);
+  border-color: rgba(88, 201, 255, 0.72);
+  box-shadow: var(--glow);
 }
 
-.cup-crossing-team.is-winner {
-  border-color: #27ae60;
-  background: color-mix(in srgb, #27ae60 16%, var(--surface-alt));
-}
-
-.cup-crossing-team.cup-crossing--winner {
-  border-color: #2fbd6f;
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, #2fbd6f 22%, var(--surface-alt)),
-    color-mix(in srgb, #0d5bcf 10%, var(--surface-alt))
-  );
-  box-shadow: 0 0 0 1px color-mix(in srgb, #2fbd6f 50%, transparent), 0 8px 24px -16px #2fbd6f;
-}
-
-.cup-crossing-team.is-winner .cup-crossing-player {
-  color: #27ae60;
+.cup-crossing-team.is-winner,
+.cup-crossing-team.cup-crossing--winner,
+.cup-crossing-score.is-winner {
+  border-color: rgba(88, 201, 255, 0.72);
+  background: rgba(88, 201, 255, 0.12);
 }
 
 .cup-crossing-team.is-loser {
-  opacity: 0.72;
+  opacity: 0.65;
+}
+
+.cup-crossing-shield,
+.cup-team-shield {
+  object-fit: contain;
+  border-radius: 0.65rem;
+  flex-shrink: 0;
 }
 
 .cup-crossing-shield {
   width: 42px;
   height: 42px;
-  object-fit: contain;
-  border-radius: 0.65rem;
-  border: 1px solid var(--line);
-  background: var(--surface);
   padding: 0.2rem;
-  flex-shrink: 0;
 }
 
 .cup-crossing-content {
   display: flex;
   align-items: center;
   gap: 0.45rem;
-  min-width: 0;
   flex-wrap: wrap;
+  min-width: 0;
 }
 
 .cup-crossing-player {
   margin: 0;
-  font-size: 0.98rem;
+  font-size: 0.95rem;
   font-weight: 700;
   line-height: 1.2;
   word-break: break-word;
 }
 
 .cup-crossing-division {
-  font-size: 0.72rem;
-  line-height: 1;
-  padding: 0.24rem 0.4rem;
   border-radius: 999px;
-  border: 1px solid var(--line);
-  color: var(--text-soft);
-  background: color-mix(in srgb, var(--surface) 90%, transparent);
-  opacity: 0.82;
-  white-space: nowrap;
+  font-size: 0.68rem;
+  line-height: 1;
+  padding: 0.22rem 0.36rem;
+  color: var(--text-muted);
 }
-
 
 .cup-crossing-score {
   margin-left: auto;
-  min-width: 3.25rem;
-  padding: 0.3rem 0.35rem;
+  min-width: 3.2rem;
   border-radius: 0.55rem;
-  border: 1px solid var(--line);
-  background: var(--surface);
+  padding: 0.28rem 0.33rem;
+  text-align: center;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 0.1rem;
-  flex-shrink: 0;
-  text-align: center;
-}
-
-.cup-crossing-score.is-winner {
-  border-color: #2fbd6f;
-  background: color-mix(in srgb, #2fbd6f 18%, var(--surface));
-  box-shadow: 0 0 0 1px color-mix(in srgb, #2fbd6f 48%, transparent);
 }
 
 .cup-crossing-score-main {
-  font-size: 1.05rem;
+  font-size: 1.02rem;
   font-weight: 800;
   line-height: 1;
 }
 
 .cup-crossing-score-pens {
   font-size: 0.62rem;
-  font-weight: 700;
-  line-height: 1;
-  color: var(--text-soft);
-  letter-spacing: 0.02em;
-}
-
-.pes6-ranking-row,
-.history-row {
-  border: 1px solid var(--line);
-  border-radius: 0.85rem;
-  padding: 0.75rem;
-  background: var(--surface);
+  color: var(--text-muted);
 }
 
 .pes6-ranking-header,
-.history-row-left {
+.history-row-left,
+.cup-match-body,
+.cup-team {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -757,20 +822,14 @@ summary:focus-visible,
 
 .pes6-ranking-toggle,
 .history-accordion-trigger {
-  border: 1px solid var(--line-strong);
+  border: 1px solid var(--line);
   border-radius: 0.7rem;
-  background: var(--surface-alt);
+  background: rgba(7, 14, 25, 0.82);
   color: var(--text-main);
-  padding: 0.42rem 0.7rem;
+  padding: 0.4rem 0.65rem;
   font-weight: 700;
   cursor: pointer;
 }
-
-.history-value.is-pending,
-.history-pending-badge {
-  color: var(--text-soft);
-}
-
 
 .cup-history-block {
   grid-column: 1 / -1;
@@ -778,76 +837,36 @@ summary:focus-visible,
   gap: 1rem;
 }
 
-.cup-history-heading {
-  margin: 0;
-  font-size: clamp(1.16rem, 2.6vw, 1.45rem);
-}
-
-.cup-history-title {
-  margin: 0;
-  font-size: clamp(1.08rem, 2.4vw, 1.3rem);
-}
-
-.cup-round-section {
-  border: 1px solid var(--line);
-  border-radius: var(--radius-md);
-  background: var(--surface-alt);
-  padding: 0.95rem;
-}
-
-.cup-round-title {
-  margin: 0 0 0.75rem;
-  font-size: 1rem;
-}
-
 .cup-round-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
   gap: 0.75rem;
-}
-
-.cup-match-card {
-  border: 1px solid var(--line);
-  border-radius: 0.85rem;
-  padding: 0.85rem;
-  background: var(--surface);
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .cup-match-label {
-  margin: 0 0 0.62rem;
-  font-size: 0.82rem;
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
   font-weight: 700;
-  color: var(--text-soft);
 }
 
 .cup-match-body {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
-  align-items: center;
-  gap: 0.75rem;
+  justify-content: space-between;
 }
 
 .cup-match-versus {
-  font-weight: 800;
-  font-size: 0.95rem;
-  color: var(--text-soft);
+  font-family: "Rajdhani", sans-serif;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
 }
 
 .cup-team {
-  display: flex;
-  align-items: center;
-  gap: 0.58rem;
+  justify-content: flex-start;
   min-width: 0;
 }
 
 .cup-team-shield {
   width: 36px;
   height: 36px;
-  object-fit: contain;
-  border-radius: 999px;
-  border: 1px solid var(--line);
-  background: var(--surface-alt);
-  flex-shrink: 0;
 }
 
 .cup-team-info {
@@ -857,7 +876,7 @@ summary:focus-visible,
 .cup-team-club,
 .cup-team-player {
   margin: 0;
-  line-height: 1.25;
+  line-height: 1.2;
   word-break: break-word;
 }
 
@@ -865,135 +884,152 @@ summary:focus-visible,
   font-weight: 700;
 }
 
-.cup-team-player {
-  font-size: 0.8rem;
-  color: var(--text-soft);
-}
-
 .league-modal {
   position: fixed;
-  inset: 4vh auto auto 50%;
+  inset: 3vh auto auto 50%;
   transform: translateX(-50%);
-  width: min(980px, 94vw);
-  max-height: 92vh;
+  width: min(980px, 95vw);
+  max-height: 93vh;
   overflow: auto;
   z-index: 60;
-  padding: clamp(1.25rem, 3vw, 2rem);
+  padding: clamp(1rem, 3vw, 1.8rem);
 }
 
 .modal-overlay {
   position: fixed;
   inset: 0;
   z-index: 50;
-  background: rgba(0, 0, 0, 0.55);
+  background: rgba(2, 4, 10, 0.72);
+  backdrop-filter: blur(4px);
 }
 
 .close-btn {
   position: sticky;
   top: 0;
   float: right;
-  border: 1px solid var(--line-strong);
-  border-radius: 0.72rem;
-  background: var(--surface-alt);
+  width: 2.05rem;
+  height: 2.05rem;
+  border-radius: 0.7rem;
+  border: 1px solid var(--line);
+  background: rgba(7, 14, 25, 0.92);
   color: var(--text-main);
-  font-size: 1.25rem;
+  font-size: 1.22rem;
   line-height: 1;
-  width: 2.1rem;
-  height: 2.1rem;
   cursor: pointer;
 }
 
 .tab-bar {
-  margin: 1.2rem 0 1.25rem;
-  display: flex;
-  gap: 0.7rem;
-  flex-wrap: wrap;
+  margin: 1rem 0 1.1rem;
 }
 
-.tab-btn {
-  border: 1px solid var(--line);
-  border-radius: 0.75rem;
-  background: var(--surface-alt);
-  color: var(--text-main);
-  font-size: 0.74rem;
-  font-weight: 700;
-  padding: 0.55rem 0.75rem;
-  cursor: pointer;
+.tab-panel[hidden],
+.modal-overlay[hidden],
+.league-modal[hidden] {
+  display: none !important;
 }
-
-.tab-btn.is-active {
-  color: #052035;
-  border-color: var(--accent);
-  background: var(--accent);
-}
-
-.tab-panel[hidden] { display: none; }
 
 .copy-box {
   display: grid;
-  gap: 0.7rem;
-  margin-top: 1.15rem;
+  gap: 0.65rem;
+  margin-top: 1rem;
 }
 
 .copy-box textarea {
-  width: 100%;
-  min-height: 135px;
+  min-height: 130px;
   resize: vertical;
-  border-radius: 0.95rem;
-  border: 1px solid var(--line);
-  padding: 0.9rem;
-  background: var(--surface-alt);
-  color: var(--text-main);
-  line-height: 1.65;
+  line-height: 1.6;
 }
 
 .highlight-text {
-  border-left: 3px solid var(--line-strong);
-  padding-left: 0.7rem;
-  color: var(--text-soft);
+  border-left: 2px solid var(--line-strong);
+  padding-left: 0.62rem;
 }
 
 .back-to-top {
   position: fixed;
-  right: 1rem;
-  bottom: 1rem;
+  right: 0.9rem;
+  bottom: 0.9rem;
   z-index: 40;
 }
 
+.visitor-counter,
 #visitor-counter {
   text-align: center;
-  padding: 18px 12px 30px;
-  font-size: 0.95rem;
-  opacity: 0.92;
+  padding: 16px 12px 28px;
+  font-size: 0.92rem;
+  color: var(--text-muted);
 }
 
-.modal-overlay[hidden],
-.league-modal[hidden] { display: none !important; }
+.preview-main {
+  width: min(1100px, 94%);
+  margin: 1.4rem auto 3rem;
+  display: grid;
+  gap: 1rem;
+}
 
-@media (min-width: 900px) {
+.preview-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.preview-list,
+.preview-matches {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--bg-card-strong);
+  padding: 1rem;
+}
+
+.preview-item {
+  padding: 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: 0.7rem;
+  background: rgba(9, 16, 28, 0.64);
+  margin-bottom: 0.55rem;
+}
+
+.preview-item:last-child {
+  margin-bottom: 0;
+}
+
+.preview-modal-demo {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: rgba(3, 7, 14, 0.6);
+  backdrop-filter: blur(2px);
+  padding: 0.9rem;
+}
+
+.preview-modal-card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  padding: 1rem;
+}
+
+@media (min-width: 860px) {
   .season-grid,
-  .league-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
+  .league-grid,
   .history-layout,
-  .palmares-layout {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
+  .palmares-layout,
+  .preview-grid,
   .cup-round-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .cup-history-toolbar {
-    justify-content: flex-start;
   }
 }
 
 @media (max-width: 768px) {
   .section {
-    width: min(1120px, 94%);
-    padding: clamp(3rem, 10vw, 4rem) 0;
+    width: min(1160px, 94%);
+    padding: clamp(2.2rem, 10vw, 3.4rem) 0;
+  }
+
+  .topbar-inner {
+    width: min(1160px, 94%);
+  }
+
+  .topbar-title {
+    font-size: 0.95rem;
   }
 
   .hero-copy,
@@ -1008,24 +1044,26 @@ summary:focus-visible,
     width: 100%;
     flex-direction: column;
     align-items: stretch;
-    gap: 0.85rem;
   }
 
   .hero-actions .btn,
   .tab-btn,
   .copy-btn,
-  .back-to-top {
+  .back-to-top,
+  .cup-tab-btn,
+  .topbar-preview-link {
     width: 100%;
     text-align: center;
     justify-content: center;
   }
 
-  .season-card,
   .league-card-content,
+  .season-card,
   .panel-section,
   .faq,
-  .about-section {
-    padding: 1.4rem;
+  .about-section,
+  .league-modal {
+    padding: 1rem;
   }
 
   .season-card-header {
@@ -1035,18 +1073,29 @@ summary:focus-visible,
 
   .league-card-banner,
   .modal-banner {
-    height: 250px;
-  }
-
-  .season-end {
-    font-size: clamp(1.05rem, 5.5vw, 1.35rem);
-    padding: 1.1rem;
+    height: 215px;
   }
 
   .league-modal {
-    inset: 2vh auto auto 50%;
-    width: 95vw;
-    max-height: 95vh;
-    padding: 1rem;
+    inset: 1.5vh auto auto 50%;
+    max-height: 96vh;
+  }
+
+  .cup-history-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .cup-history-toolbar select {
+    max-width: none;
+  }
+
+  .cup-match-body {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .cup-match-versus {
+    align-self: center;
   }
 }


### PR DESCRIPTION
### Motivation
- Actualizar la apariencia de toda la web hacia un tema oscuro, sobrio y competitivo con un único acento celeste y glow suave en estados interactivos, sin alterar contenido ni funcionalidad. 
- Proveer una vista de `preview` navegable para validar y revisar componentes visuales (botones, tarjetas, cruces, modales) antes de desplegar en producción.

### Description
- Centralicé y reescribí la hoja de estilos en `styles.css` implementando un Design System con variables en `:root` (paleta oscuro, `--accent` celeste, sombras suaves, `--glow`), tipografías `Rajdhani` + `Inter`, y componentes estandarizados para botones, tarjetas, badges, tabs, listas, cruces y modales. 
- Actualicé `index.html` para cargar las nuevas fuentes, añadí una `topbar` con placeholder para el escudo y convertí el contador de visitantes a una clase CSS para mantener separación de presentación. 
- Añadí `preview.html` como página interna de validación que muestra header, botones en todos los estados, tarjetas, ejemplos de listas de temporadas, ejemplo de cruces (pendiente/jugado/ganador) y un demo de modal/cajón abierto. 
- Mantengo enfoque mobile-first y ajustes responsivos para que no se rompan los layouts en móvil; no se modificó ningún texto o dato existente.

### Testing
- Ejecuté la comprobación de sintaxis JS con `node --check app.js` y la verificación final fue exitosa. 
- Inicié un servidor estático con `python3 -m http.server 4173` y confirmé que `index.html` y `preview.html` sirven correctamente en `http://localhost:4173/`. 
- Ejecuté un script automático de Playwright que navegó `index.html` y `preview.html` en viewport móvil y generó capturas (artifacts de la ejecución): `home-mobile.png`, `cruces-mobile.png`, `modal-mobile.png`, `preview-page-mobile.png`, con la ejecución completada exitosamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bb089b180833299cec14809da7707)