### PR TITLE
Estilo global: oscuro sobrio, neón controlado y espaciado mejorado

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&family=Rajdhani:wght@500;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css?v=20260210-navy-minimal" />
+  <link rel="stylesheet" href="styles.css?v=20260210-neon-controlled" />
 </head>
 <body>
   <div class="bg-effects" aria-hidden="true"></div>

--- a/preview.html
+++ b/preview.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&family=Rajdhani:wght@500;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css?v=20260210-dark-competitive" />
+  <link rel="stylesheet" href="styles.css?v=20260210-neon-controlled" />
 </head>
 <body>
   <div class="bg-effects" aria-hidden="true"></div>

--- a/styles.css
+++ b/styles.css
@@ -15,7 +15,8 @@
   --radius-lg: 1.3rem;
   --shadow-soft: 0 14px 34px rgba(0, 0, 0, 0.34);
   --shadow-card: 0 16px 26px rgba(0, 0, 0, 0.26);
-  --glow: 0 0 0 1px var(--accent-soft), 0 0 26px -10px var(--accent);
+  --glow: 0 0 0 1px rgba(88, 201, 255, 0.28), 0 0 12px -6px rgba(88, 201, 255, 0.45), 0 0 22px -16px rgba(88, 201, 255, 0.35);
+  --divider-glow: 0 5px 12px -8px rgba(88, 201, 255, 0.65);
   --max-width: min(1160px, 92%);
 }
 
@@ -35,9 +36,7 @@ body {
   font-size: 16px;
   line-height: 1.7;
   color: var(--text-main);
-  background:
-    radial-gradient(1200px 560px at 50% -260px, rgba(88, 201, 255, 0.12), transparent 65%),
-    linear-gradient(180deg, #040913 0%, var(--bg-main) 42%, #060d18 100%);
+  background: linear-gradient(180deg, #040913 0%, var(--bg-main) 44%, #060d18 100%);
 }
 
 body.no-scroll {
@@ -58,7 +57,13 @@ body.no-scroll {
 .section {
   width: var(--max-width);
   margin: 0 auto;
-  padding: clamp(3rem, 8vw, 5rem) 0;
+  padding: 0;
+}
+
+main {
+  display: grid;
+  gap: clamp(1.75rem, 6vw, 2.25rem);
+  padding: clamp(1.75rem, 5vw, 2.4rem) 0 clamp(2.2rem, 5vw, 3rem);
 }
 
 h1,
@@ -157,6 +162,7 @@ a {
 .hero {
   text-align: center;
   padding-top: clamp(4rem, 9vw, 6.6rem);
+  padding-bottom: clamp(2rem, 5vw, 2.8rem);
 }
 
 .hero-kicker {
@@ -288,6 +294,7 @@ summary:focus-visible,
   bottom: -0.45rem;
   height: 1px;
   background: linear-gradient(90deg, transparent, var(--line), transparent);
+  box-shadow: var(--divider-glow);
 }
 
 .panel-section,
@@ -297,8 +304,6 @@ summary:focus-visible,
 .season-card,
 .palmares-block,
 .pes6-ranking,
-.season-status,
-.about-section,
 .cup-crossings-panel {
   border: 1px solid var(--line);
   border-radius: var(--radius-lg);
@@ -306,11 +311,19 @@ summary:focus-visible,
   box-shadow: var(--shadow-card);
 }
 
-.season-status,
 .panel-section,
 .faq,
-.about-section {
+.about-section,
+.donations-section {
   padding: clamp(1.4rem, 5vw, 2.5rem);
+}
+
+.season-status {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .season-grid,
@@ -322,7 +335,7 @@ summary:focus-visible,
 .cup-interdivisional-rounds,
 .cup-crossing-body {
   display: grid;
-  gap: 0.95rem;
+  gap: clamp(0.9rem, 2.8vw, 1.12rem);
 }
 
 .season-card {
@@ -433,7 +446,7 @@ summary:focus-visible,
 .sponsor-card:hover,
 .sponsor-card:focus-visible {
   border-color: rgba(88, 201, 255, 0.52);
-  box-shadow: var(--shadow-card), var(--glow);
+  box-shadow: var(--shadow-card);
 }
 
 .league-card-banner,
@@ -670,6 +683,7 @@ summary:focus-visible,
 .tab-btn.is-active {
   border-color: rgba(88, 201, 255, 0.72);
   background: rgba(88, 201, 255, 0.14);
+  box-shadow: var(--glow);
 }
 
 .cup-tab-panel {
@@ -728,7 +742,6 @@ summary:focus-visible,
 
 .cup-crossing-team.is-selectable:hover {
   border-color: rgba(88, 201, 255, 0.72);
-  box-shadow: var(--glow);
 }
 
 .cup-crossing-team.is-winner,
@@ -736,6 +749,16 @@ summary:focus-visible,
 .cup-crossing-score.is-winner {
   border-color: rgba(88, 201, 255, 0.72);
   background: rgba(88, 201, 255, 0.12);
+  box-shadow: var(--glow);
+}
+
+.faq,
+.about-section,
+.donations-section {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .cup-crossing-team.is-loser {
@@ -1021,7 +1044,11 @@ summary:focus-visible,
 @media (max-width: 768px) {
   .section {
     width: min(1160px, 94%);
-    padding: clamp(2.2rem, 10vw, 3.4rem) 0;
+  }
+
+  main {
+    gap: clamp(1.75rem, 7vw, 2.25rem);
+    padding: clamp(1.75rem, 8vw, 2.25rem) 0 clamp(2rem, 8vw, 2.5rem);
   }
 
   .topbar-inner {
@@ -1062,6 +1089,7 @@ summary:focus-visible,
   .panel-section,
   .faq,
   .about-section,
+  .donations-section,
   .league-modal {
     padding: 1rem;
   }


### PR DESCRIPTION
### Motivation
- Unificar la apariencia de la web manteniendo un tema oscuro profesional con acentos de neón controlados en elementos clave. 
- Quitar paneles/paneles globales que envuelven secciones para que el contenido respire y sea mobile-first. 
- Aplicar glow sutil solo a CTAs/estados importantes y separadores, sin afectar fondos ni tarjetas grandes.

### Description
- Actualiza `styles.css` para introducir `--glow` más moderado y `--divider-glow` y reduce efectos de fondo general para evitar un look futurista excesivo. 
- Convierte el layout principal a un stack mobile-first con `main { display: grid; gap: ... }` y elimina padding global de `.section` para controlar espaciados con `gap` y padding en `main`. 
- Deja `.season-status` sin fondo, borde, radius ni sombra para que la sección quede abierta sobre el fondo del `body` y mantiene solo las cards internas como tarjetas independientes. 
- Remueve el glow en hover de cards grandes y aplica glow puntual en `tab-btn.is-active` y en estados ganadores/activos; agrega glow sutil a separators (`.hud-separator::after`). 
- Elimina cajas de fondo en secciones informativas (`.faq`, `.about-section`, `.donations-section`) manteniendo sus elementos internos intactos. 
- Actualiza el cache-buster de `styles.css` en `index.html` y `preview.html` a `?v=20260210-neon-controlled` para forzar recarga de estilos.

### Testing
- `node --check app.js` se ejecutó y pasó correctamente. 
- Intenté arrancar un servidor estático con `python3 -m http.server 4173` y conectar con `curl`, pero la conexión falló en este entorno (proceso no quedó disponible), por lo que la validación de servidor local no pudo completarse. 
- Ejecuté intentos de captura con Playwright (`chromium`, `firefox`, `webkit`) para generar screenshots de preview y todos fallaron por restricciones/crashes del entorno, por lo que no se pudo producir la captura visual automática.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bb39f2ff88332898d2b602603eab5)