### PR TITLE
Corregir ruta del logo del header para GitHub Pages (ruta relativa)

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       <a class="topbar-brand" href="#inicio" aria-label="Ir al inicio">
         <img
           class="topbar-logo"
-          src="/assets/sudaka-league-logo.png"
+          src="assets/sudaka-league-logo.png"
           alt="Logo de Sudaka League"
           onerror="this.style.display='none'; this.nextElementSibling.hidden = false;"
         />

--- a/preview.html
+++ b/preview.html
@@ -18,7 +18,7 @@
       <a class="topbar-brand" href="index.html" aria-label="Volver al inicio real">
         <img
           class="topbar-logo"
-          src="/assets/sudaka-league-logo.png"
+          src="assets/sudaka-league-logo.png"
           alt="Logo de Sudaka League"
           onerror="this.style.display='none'; this.nextElementSibling.hidden = false;"
         />


### PR DESCRIPTION
### Motivation
- GitHub Pages sirve el sitio bajo el subpath `/sudaka-league/` por lo que la URL absoluta `"/assets/sudaka-league-logo.png"` resolvía incorrectamente y ocultaba el logo en el header.

### Description
- Cambié solo el atributo `src` del `<img>` del header de `src="/assets/sudaka-league-logo.png"` a `src="assets/sudaka-league-logo.png"` en `index.html` y en `preview.html` para usar una ruta relativa sin `/` inicial.

### Testing
- Ejecuté `rg 'src="/assets/sudaka-league-logo.png"|src="assets/sudaka-league-logo.png"' -n index.html preview.html` para verificar las referencias y confirmarlas; la búsqueda devolvió las dos entradas actualizadas (éxito). 
- Ejecuté `git commit -m "Fix header logo path for GitHub Pages subpath"` para registrar el cambio (commit realizado con éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bbebeb86c83328438a14fe04b28b1)