### PR TITLE
fix(copa): restaurar visualización de resultados y resaltado de ganador en Copa Interdivisional

### DIFF
--- a/app.js
+++ b/app.js
@@ -1250,7 +1250,7 @@ function isMatchPlayed(match, seasonStatus = "active") {
     }
   }
 
-  return seasonStatus === "completed" && (!!normalizeMatchResult(match.result) || normalizeWinnerValue(match.winner) != null);
+  return !!normalizeMatchResult(match.result) || normalizeWinnerValue(match.winner) != null;
 }
 
 function normalizeMatchData(match, seasonStatus = "active") {


### PR DESCRIPTION
### Motivation
- Se detectó que los cruces con `result` o `winner` cargados dejaron de considerarse "jugados" por una condición en `isMatchPlayed`, provocando que desaparecieran los scores y que el winner dejara de resaltarse en la tarjeta de la copa.

### Description
- Se actualizó `app.js` para que `isMatchPlayed(match, seasonStatus)` retorne `true` cuando exista un `result` válido o un `winner` válido sin requerir que la temporada esté `completed`, restaurando así la renderización previa de resultados y el estado visual del ganador.

### Testing
- Ejecutado `node --check app.js` y pasó correctamente.
- Intenté una verificación UI con Playwright para capturar la tarjeta, pero el navegador falla por razones del entorno (Playwright/Chromium crashea) y esa prueba automatizada no pudo completarse.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bc64357888332abae33e6180dfd41)