### PR TITLE
Fix layout overlap in Palmarés → Historial accordion on mobile

### DIFF
--- a/styles-v2.css
+++ b/styles-v2.css
@@ -395,6 +395,10 @@ summary:focus-visible,
   gap: clamp(0.9rem, 2.8vw, 1.12rem);
 }
 
+.history-layout {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .season-card {
   padding: clamp(1.1rem, 3vw, 1.7rem);
   background: linear-gradient(180deg, rgba(26, 40, 62, 0.88), rgba(14, 24, 39, 0.92));
@@ -908,6 +912,17 @@ summary:focus-visible,
   border-top: 1px solid var(--line);
 }
 
+.history-accordion-panel {
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transition: max-height 280ms ease, opacity 220ms ease;
+}
+
+.history-accordion-panel[data-expanded="true"] {
+  opacity: 1;
+}
+
 .pes6-ranking-toggle,
 .history-accordion-trigger {
   border: 1px solid var(--line);
@@ -1099,7 +1114,6 @@ summary:focus-visible,
 @media (min-width: 860px) {
   .season-grid,
   .league-grid,
-  .history-layout,
   .palmares-layout,
   .preview-grid,
   .cup-round-grid {


### PR DESCRIPTION
### Motivation
- The season cards in the Palmarés → Historial accordion were overlapping because collapsed panels leaked height and the history container could appear as multi-column on wider viewports, breaking the normal DOM flow and causing encimamientos, especially on small viewports.

### Description
- Modified `styles-v2.css` to add proper accordion panel rules: `.history-accordion-panel` now uses `overflow: hidden`, `max-height: 0`, `opacity` and a `transition` so collapsed panels do not affect subsequent items and expansion is animated via `data-expanded`.
- Enforced a single-column stack for the history container by adding `grid-template-columns: minmax(0, 1fr)` to `.history-layout` so each season occupies its own vertical block.
- Removed `.history-layout` from the desktop two-column media-query to avoid side-by-side season cards that caused layout conflicts.
- No data, titles or JS logic were changed; only CSS structural rules were adjusted and visual styles (borders, glow, colors) were preserved.

### Testing
- Ran JavaScript syntax checks with `node --check app.js`, `node --check data/interdivisional.js` and `node --check data/interdivisional_history.js`, and they succeeded.
- Served the site locally with `python3 -m http.server 4173` and exercised the PES6 modal + History tab in an automated Playwright script (mobile viewport `390x844`) that opened all accordion items; the automated check reported `items=6 overlap=False` indicating no overlap.
- Captured visual screenshots before/after the fix via the Playwright run to validate the mobile rendering (artifacts produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bc99d0f7483329ee5f5230e81a135)