### PR TITLE
Separar render de Ranking e Historial en modal PES6 (fix scope)

### DIFF
--- a/app.js
+++ b/app.js
@@ -627,6 +627,16 @@ function activateTab(modal, tabButton) {
     panel.hidden = !isActive;
     panel.classList.toggle("is-active", isActive);
   });
+
+  if (modal.id === "pes6-panel") {
+    if (targetPanelId === "pes6-tab-history") {
+      renderPes6History();
+    }
+
+    if (targetPanelId === "pes6-tab-ranking") {
+      renderPes6Ranking();
+    }
+  }
 }
 
 function setupTabs() {
@@ -1769,7 +1779,6 @@ async function initializeApp() {
   setupTabs();
   renderPalmares();
   renderPes6Ranking();
-  renderPes6History();
   setupCupCrossingsAccordion();
   await initializeInterdivisionalState();
   applyKofLeagueContent();


### PR DESCRIPTION
### Motivation
- Corregir un problema de alcance donde el contenido de "Historial" (acordeones de temporadas) se estaba mostrando dentro de la sección "Ranking de títulos". 
- Asegurar que la sección "Ranking de títulos" muestre solo el ranking por cantidad de títulos y que el "Historial" exista únicamente en su pestaña dedicada. 
- No cambiar estilos, datos ni la lógica del ranking; solo ajustar cuándo/qué se renderiza en la UI.

### Description
- Renderizado bajo demanda: se actualizó `activateTab(...)` en `app.js` para ejecutar `renderPes6History()` solo cuando se activa `pes6-tab-history` y `renderPes6Ranking()` solo cuando se activa `pes6-tab-ranking` dentro del modal PES6. 
- Se eliminó la llamada de render global de historial en `initializeApp()` para evitar que el markup de Historial exista fuera de su pestaña. 
- No se modificaron funciones de cálculo, datos ni estilos; el único archivo cambiado es `app.js` y la lógica de render se mantiene idéntica salvo el scope de invocación. 

### Testing
- Se verificó la sintaxis con `node --check app.js` y la comprobación fue exitosa. 
- Se lanzó un servidor estático y se ejecutó un script automático con Playwright (viewport móvil 390x844) que abre el modal PES6 y selecciona la pestaña "Ranking de títulos" para validar que no se muestran acordeones de temporada, y la prueba concluyó con éxito (screenshot generado). 
- No se introdujeron fallos de runtime durante las verificaciones locales automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bcc9124508332ab2b2a2747e5dc52)