### PR TITLE
Fix Ranking de Títulos: remover contenido de Historial del panel de detalle

### DIFF
--- a/app.js
+++ b/app.js
@@ -862,11 +862,6 @@ function isValidTitleWinner(value) {
   return !invalidValues.includes(normalized.toUpperCase());
 }
 
-function getSeasonOrder(seasonLabel = "") {
-  const match = seasonLabel.match(/(\d+)/);
-  return match ? Number(match[1]) : 0;
-}
-
 function buildPes6TitleMap(history) {
   const titleMap = {};
 
@@ -891,8 +886,7 @@ function buildPes6TitleMap(history) {
         if (!titleMap[player]) {
           titleMap[player] = {
             total: 0,
-            counts: { primera: 0, copas: 0, individuales: 0 },
-            items: []
+            counts: { primera: 0, copas: 0, individuales: 0 }
           };
         }
 
@@ -901,19 +895,8 @@ function buildPes6TitleMap(history) {
         if (groupKey === "divisions") titleMap[player].counts.primera += 1;
         if (groupKey === "cups") titleMap[player].counts.copas += 1;
         if (groupKey === "awards") titleMap[player].counts.individuales += 1;
-
-        titleMap[player].items.push({
-          season: seasonData.season,
-          type: meta.type,
-          title: meta.title,
-          order: getSeasonOrder(seasonData.season)
-        });
       });
     });
-  });
-
-  Object.values(titleMap).forEach((playerData) => {
-    playerData.items.sort((a, b) => b.order - a.order || a.title.localeCompare(b.title, "es"));
   });
 
   return titleMap;
@@ -1007,12 +990,7 @@ function createPes6RankingItem(player, playerData, index) {
   breakdown.className = "pes6-ranking-breakdown";
   breakdown.textContent = `Primera División: ${playerData.counts.primera} | Copas: ${playerData.counts.copas} | Individuales: ${playerData.counts.individuales}`;
 
-  const titles = playerData.items.map((item) => `${item.season} ${item.title}`);
-  const titlesLine = document.createElement("p");
-  titlesLine.className = "pes6-ranking-titles";
-  titlesLine.textContent = `Títulos: ${titles.join(" | ")}`;
-
-  panel.append(breakdown, titlesLine);
+  panel.append(breakdown);
 
   toggle.addEventListener("click", () => {
     const isOpen = toggle.getAttribute("aria-expanded") === "true";


### PR DESCRIPTION
### Motivation
- El panel "Ranking de Títulos" estaba mostrando contenido del `Historial` (acordeón/temporadas y títulos) y debe contener solo el ranking y un detalle mínimo por jugador. 
- Se necesita desacoplar la UI para que el listado histórico permanezca únicamente en `Palmarés → Historial` sin tocar estilos ni otras secciones.

### Description
- Modificado `app.js` para que `buildPes6TitleMap` deje de generar/almacenar la lista de `items` por temporada y solo mantenga contadores agregados (`total` y `counts`).
- Eliminada la función auxiliar de orden de temporadas `getSeasonOrder` que quedó sin uso tras el cambio.
- Actualizado `createPes6RankingItem` para que el panel expandible muestre únicamente el `breakdown` (`Primera División | Copas | Individuales`) y no renderice la línea de títulos por temporada; el histórico queda intacto y sigue siendo renderizado por `renderPes6History()` en su pestaña.
- Cambios contenidos en un único archivo modificado: `app.js` (código completo del archivo fue incluido en la revisión).

### Testing
- Ejecutado `node --check app.js` para validar sintaxis de JavaScript y resultó exitoso.
- Levantado servidor con `python3 -m http.server 4173` y se comprobó carga de la página; servidor iniciado correctamente.
- Script automatizado con Playwright abrió la página (`/index.html`), navegó a `PES 6` → `Ranking de títulos`, hizo clic en el botón de detalle y tomó una captura de pantalla; la verificación visual mostró que el panel de detalle contiene únicamente el desglose y no el acordeón de temporadas (ejecución exitosa).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bcf6c2ef883328223858546a933a0)