### PR TITLE
Fix PES6 ranking detail expansion overlap on mobile

### DIFF
--- a/styles-v2.css
+++ b/styles-v2.css
@@ -388,11 +388,16 @@ summary:focus-visible,
 .history-layout,
 .palmares-layout,
 .palmares-grid,
-.pes6-ranking-list-wrap,
 .cup-interdivisional-rounds,
 .cup-crossing-body {
   display: grid;
   gap: clamp(0.9rem, 2.8vw, 1.12rem);
+}
+
+.pes6-ranking-list-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .history-layout {
@@ -679,6 +684,15 @@ summary:focus-visible,
   padding: 0.75rem;
 }
 
+.pes6-ranking-row {
+  position: relative;
+  height: auto;
+  max-height: none;
+  overflow: hidden;
+  padding: 12px;
+  border-radius: 14px;
+}
+
 .palmares-trophy,
 .history-trophy {
   width: 40px;
@@ -905,11 +919,48 @@ summary:focus-visible,
   gap: 0.6rem;
 }
 
+.pes6-ranking-header {
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.pes6-ranking-position,
+.pes6-ranking-total,
+.pes6-ranking-total-label {
+  white-space: nowrap;
+}
+
+.pes6-ranking-player {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.pes6-ranking-stats {
+  display: flex;
+  align-items: baseline;
+  gap: 0.25rem;
+}
+
 .pes6-ranking-panel,
 .history-accordion-panel {
   margin-top: 0.65rem;
   padding-top: 0.65rem;
   border-top: 1px solid var(--line);
+}
+
+.pes6-ranking-panel {
+  position: static;
+}
+
+.pes6-ranking-breakdown {
+  margin: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  line-height: 1.25;
 }
 
 .history-accordion-panel {
@@ -932,6 +983,34 @@ summary:focus-visible,
   padding: 0.4rem 0.65rem;
   font-weight: 700;
   cursor: pointer;
+}
+
+@media (max-width: 420px) {
+  .pes6-ranking-header {
+    grid-template-columns: 44px minmax(0, 1fr) auto;
+    grid-template-areas:
+      "position player toggle"
+      "position stats stats";
+    grid-auto-rows: auto;
+    row-gap: 6px;
+  }
+
+  .pes6-ranking-position {
+    grid-area: position;
+  }
+
+  .pes6-ranking-player {
+    grid-area: player;
+  }
+
+  .pes6-ranking-stats {
+    grid-area: stats;
+  }
+
+  .pes6-ranking-toggle {
+    grid-area: toggle;
+    justify-self: end;
+  }
 }
 
 .cup-history-block {


### PR DESCRIPTION
### Motivation
- Fix a mobile bug where the PES6 “Ranking de Títulos” detail panel overlapped the following rows instead of pushing them down when opened.
- Remove layout rules that caused overlays (fixed heights/max-heights or absolute positioning) and restore normal flow for the detail block.
- Improve wrapping and spacing so long detail text and player names don't break layout on small viewports.

### Description
- Converted the ranking list wrapper to a vertical stack by adding `.pes6-ranking-list-wrap { display: flex; flex-direction: column; gap: 12px; }` so items are a real column.
- Updated `.pes6-ranking-row` to use `position: relative`, `height: auto`, `max-height: none`, `overflow: hidden`, increased `padding` and `border-radius` to avoid clipped overlays and allow rows to grow vertically.
- Reworked `.pes6-ranking-header` into a grid (`52px minmax(0, 1fr) auto auto`) and added a responsive `@media (max-width: 420px)` rule that reflows header components and keeps the toggle aligned and clickable.
- Ensured detail content stays in document flow by setting `.pes6-ranking-panel { position: static; }` and improved detail wrapping via `.pes6-ranking-breakdown { white-space: normal; overflow-wrap: anywhere; word-break: break-word; line-height: 1.25; }`.

### Testing
- Ran `node --check app.js` to validate JS syntax and it succeeded.
- Started a local HTTP server and attempted an automated Playwright check in a mobile viewport, but Chromium crashed with `SIGSEGV` in this environment so visual screenshot validation could not be produced.
- Inspected the updated `styles-v2.css` file to verify the new rules are present and no CSS syntax errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c6179b7a08332896a18a7a11a8f79)