### PR TITLE
Fix PES6 ranking detail toggle and mobile name wrapping

### DIFF
--- a/styles-v2.css
+++ b/styles-v2.css
@@ -919,7 +919,8 @@ summary:focus-visible,
   gap: 0.6rem;
 }
 
-.pes6-ranking-header {
+.pes6-ranking-header,
+.rankingHeaderRow {
   display: grid;
   grid-template-columns: 52px minmax(0, 1fr) auto auto;
   align-items: center;
@@ -932,10 +933,12 @@ summary:focus-visible,
   white-space: nowrap;
 }
 
-.pes6-ranking-player {
+.pes6-ranking-player,
+.rankingName {
   min-width: 0;
-  overflow-wrap: anywhere;
-  word-break: break-word;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .pes6-ranking-stats {
@@ -957,6 +960,14 @@ summary:focus-visible,
 
 .pes6-ranking-breakdown {
   margin: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  line-height: 1.25;
+}
+
+.pes6-ranking-details {
+  margin-top: 10px;
   white-space: normal;
   overflow-wrap: anywhere;
   word-break: break-word;
@@ -986,29 +997,36 @@ summary:focus-visible,
 }
 
 @media (max-width: 420px) {
-  .pes6-ranking-header {
+  .pes6-ranking-header,
+  .rankingHeaderRow {
     grid-template-columns: 44px minmax(0, 1fr) auto;
     grid-template-areas:
-      "position player toggle"
-      "position stats stats";
+      "pos name btn"
+      ". meta btn";
     grid-auto-rows: auto;
     row-gap: 6px;
   }
 
-  .pes6-ranking-position {
-    grid-area: position;
+  .pes6-ranking-position,
+  .rankingPos {
+    grid-area: pos;
   }
 
-  .pes6-ranking-player {
-    grid-area: player;
+  .pes6-ranking-player,
+  .rankingName {
+    grid-area: name;
   }
 
-  .pes6-ranking-stats {
-    grid-area: stats;
+  .pes6-ranking-stats,
+  .rankingMeta {
+    grid-area: meta;
+    font-size: 12px;
+    opacity: 0.9;
   }
 
-  .pes6-ranking-toggle {
-    grid-area: toggle;
+  .pes6-ranking-toggle,
+  .rankingBtn {
+    grid-area: btn;
     justify-self: end;
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent the ranking detail block from being always present and occupying layout space by rendering it only when the user explicitly opens a row. 
- Ensure only one detail row can be open at a time (toggle/replace behavior). 
- Fix ugly name breaks on mobile by applying proper truncation and reflow rules so names show a single-line ellipsis or push metadata below when needed.

### Description
- Added a single-open state `openTitlesRankingId` and updated `renderPes6Ranking()` and `createPes6RankingItem()` to accept an `isOpen` flag so the detail panel is conditionally rendered only for the open row, and clicking the toggle sets `openTitlesRankingId` (or clears it) to open/close rows. (`app.js`)
- Replaced the old panel animation/always-mounted approach with conditional panel creation so collapsed rows do not render the detail DOM at all and the toggle label switches between `"Ver detalle"` and `"Ocultar"` while keeping `aria-expanded` updated. (`app.js`)
- Reset the open-detail state when switching between top-5 and full ranking views to avoid orphaned open state. (`app.js`)
- CSS fixes in `styles-v2.css` to make names truncate correctly: `min-width: 0`, `overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`; mobile grid adjusted to `minmax(0, 1fr)` and grid-template-areas to move the stats below the name when space is tight; added `.pes6-ranking-details` rules for better multiline detail wrapping. (`styles-v2.css`)
- Added helper class names on DOM nodes to match new CSS selectors (`rankingHeaderRow`, `rankingName`, `rankingPos`, `rankingMeta`, `rankingBtn`) to keep the visual style while enabling the new layout rules. (`app.js`, `styles-v2.css`)

### Testing
- Ran `node --check app.js` to verify the modified script parses without syntax errors, which succeeded. 
- Served the app with `python3 -m http.server` and verified `curl -I http://127.0.0.1:4173/index.html` returned `200 OK`. 
- Automated UI validation with Playwright in a mobile viewport (open PES6 modal → Ranking tab → click first `Ver detalle`) and captured a screenshot to confirm the detail appears only for the clicked row and the player name truncation/layout behaves correctly, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c646c63d0833288684455a1ec8849)