### PR TITLE
Unificar estilo neon-arcade en toda la web (clases sl-*)

### DIFF
--- a/app.js
+++ b/app.js
@@ -761,7 +761,7 @@ backToTopButton.addEventListener("click", () => {
 
 function createPalmaresCard(item, winnersKey, winnerLabel) {
   const card = document.createElement("article");
-  card.className = "palmares-card";
+  card.className = "palmares-card sl-card";
 
   const title = document.createElement("h4");
   title.textContent = item.nombre;
@@ -828,7 +828,7 @@ function renderPalmares() {
 
   sections.forEach((section) => {
     const block = document.createElement("section");
-    block.className = "palmares-block";
+    block.className = "palmares-block sl-card";
 
     const heading = document.createElement("h3");
     heading.textContent = section.title;
@@ -931,7 +931,7 @@ function createRankingTitlesList(playerData) {
 
 function createPes6RankingItem(player, playerData, index, isOpen) {
   const row = document.createElement("article");
-  row.className = "pes6-ranking-row";
+  row.className = "pes6-ranking-row sl-card";
 
   const header = document.createElement("div");
   header.className = "pes6-ranking-header rankingHeaderRow";
@@ -958,7 +958,7 @@ function createPes6RankingItem(player, playerData, index, isOpen) {
 
   const toggle = document.createElement("button");
   toggle.type = "button";
-  toggle.className = "pes6-ranking-toggle";
+  toggle.className = "pes6-ranking-toggle sl-pill";
   toggle.classList.add("rankingBtn");
   toggle.setAttribute("aria-expanded", String(isOpen));
   toggle.setAttribute("aria-controls", `pes6-ranking-panel-${index}`);
@@ -970,6 +970,10 @@ function createPes6RankingItem(player, playerData, index, isOpen) {
     openTitlesRankingId = openTitlesRankingId === player ? null : player;
     renderPes6Ranking();
   });
+
+  if (index === 0) {
+    row.classList.add("is-top");
+  }
 
   if (isOpen) {
     row.classList.add("is-open");
@@ -1010,7 +1014,7 @@ function renderPes6Ranking() {
   }
 
   const wrapper = document.createElement("section");
-  wrapper.className = "pes6-ranking";
+  wrapper.className = "pes6-ranking sl-card";
 
   const heading = document.createElement("h3");
   heading.textContent = "RANKING DE TÍTULOS";
@@ -1034,7 +1038,7 @@ function renderPes6Ranking() {
 
   const listToggle = document.createElement("button");
   listToggle.type = "button";
-  listToggle.className = "pes6-ranking-toggle";
+  listToggle.className = "pes6-ranking-toggle sl-pill";
   listToggle.textContent = showAllTitlesRanking ? "Ver top 5" : "Ver todos";
   listToggle.style.margin = "0.85rem auto 0";
   listToggle.style.display = "flex";
@@ -1051,7 +1055,7 @@ function renderPes6Ranking() {
 
 function createHistoryRow(itemMeta, value) {
   const row = document.createElement("div");
-  row.className = "history-row";
+  row.className = "history-row sl-card";
 
   const left = document.createElement("div");
   left.className = "history-row-left";
@@ -1088,7 +1092,7 @@ function createHistoryRow(itemMeta, value) {
 
 function createHistorySection(title, itemsMeta, values = {}) {
   const section = document.createElement("section");
-  section.className = "history-section";
+  section.className = "history-section sl-card";
 
   const heading = document.createElement("h4");
   heading.textContent = title;
@@ -1145,11 +1149,11 @@ function animateHistoryPanel(panel, expand) {
 
 function createHistoryAccordionItem(seasonData, index) {
   const item = document.createElement("article");
-  item.className = "history-accordion-item";
+  item.className = "history-accordion-item sl-card";
 
   const trigger = document.createElement("button");
   trigger.type = "button";
-  trigger.className = "history-accordion-trigger";
+  trigger.className = "history-accordion-trigger sl-pill";
   trigger.setAttribute("aria-expanded", "false");
   trigger.setAttribute("aria-controls", `pes6-history-panel-${index}`);
   trigger.innerHTML = `<span>${seasonData.season}</span><span class="history-chevron" aria-hidden="true">⌄</span>`;

--- a/index.html
+++ b/index.html
@@ -37,16 +37,16 @@
       sin horarios fijos y coordinando partidas por WhatsApp
     </p>
     <div class="hero-actions">
-      <a id="cta-comunidad" class="btn btn-primary neon-box" href="https://chat.whatsapp.com/DvRyA2bxAC67x0ulPQYvCa?mode=gi_t" target="_blank" rel="noopener noreferrer">Unirme a la comunidad</a>
-      <a class="btn btn-secondary neon-box" href="#ligas">Ver ligas</a>
+      <a id="cta-comunidad" class="btn sl-btn btn-primary neon-box" href="https://chat.whatsapp.com/DvRyA2bxAC67x0ulPQYvCa?mode=gi_t" target="_blank" rel="noopener noreferrer">Unirme a la comunidad</a>
+      <a class="btn sl-btn btn-secondary neon-box" href="#ligas">Ver ligas</a>
     </div>
   </header>
 
   <main>
-    <section class="section hud-separator season-status" aria-labelledby="season-status-title">
-      <h2 id="season-status-title" class="neon-text">ESTADO DE TEMPORADA</h2>
+    <section class="section hud-separator sl-divider season-status" aria-labelledby="season-status-title">
+      <h2 id="season-status-title" class="neon-text sl-section-title">ESTADO DE TEMPORADA</h2>
       <div class="season-grid">
-        <article class="season-card neon-box neon-border" aria-labelledby="pes6-season-title">
+        <article class="season-card sl-card neon-box neon-border" aria-labelledby="pes6-season-title">
           <div class="season-card-header">
             <h3 id="pes6-season-title">⚽ PES 6 – Infinity Patch</h3>
             <span id="pes6Status" class="season-badge season-badge-active neon-box">ACTIVA</span>
@@ -60,7 +60,7 @@
           </div>
         </article>
 
-        <article class="season-card neon-box neon-border" aria-labelledby="kof-season-title">
+        <article class="season-card sl-card neon-box neon-border" aria-labelledby="kof-season-title">
           <div class="season-card-header">
             <h3 id="kof-season-title">🥊 —</h3>
             <span id="sfStatus" class="season-badge season-badge-wait neon-border">EN ESPERA</span>
@@ -77,7 +77,7 @@
     </section>
 
     <section class="section hud-separator cup-interdivisional-section" aria-labelledby="cup-season-title">
-      <article id="cup-interdivisional-card" class="season-card cup-interdivisional-card neon-box neon-border" role="button" tabindex="0" aria-expanded="false" aria-controls="cup-crossings-panel">
+      <article id="cup-interdivisional-card" class="season-card sl-card cup-interdivisional-card neon-box neon-border" role="button" tabindex="0" aria-expanded="false" aria-controls="cup-crossings-panel">
         <div class="season-card-header">
           <h3 id="cup-season-title">Copa Interdivisional SLP</h3>
           <span id="cupStatus" class="season-badge season-badge-active neon-box">ACTIVA</span>
@@ -90,8 +90,8 @@
 
       <div id="cup-crossings-panel" class="cup-crossings-panel neon-border" hidden>
         <div class="cup-card-tabs" role="tablist" aria-label="Contenido Copa Interdivisional">
-          <button id="cup-tab-active" class="cup-tab-btn is-active neon-box" type="button" role="tab" aria-selected="true" aria-controls="cup-tab-panel-active">Activa</button>
-          <button id="cup-tab-history" class="cup-tab-btn neon-box" type="button" role="tab" aria-selected="false" aria-controls="cup-tab-panel-history">Historial Interdivisional</button>
+          <button id="cup-tab-active" class="cup-tab-btn sl-tab is-active neon-box" type="button" role="tab" aria-selected="true" aria-controls="cup-tab-panel-active">Activa</button>
+          <button id="cup-tab-history" class="cup-tab-btn sl-tab neon-box" type="button" role="tab" aria-selected="false" aria-controls="cup-tab-panel-history">Historial Interdivisional</button>
         </div>
 
         <section id="cup-tab-panel-active" class="cup-tab-panel is-active" role="tabpanel" aria-labelledby="cup-tab-active">
@@ -111,7 +111,7 @@
     <section id="ligas" class="section hud-separator" aria-labelledby="ligas-title">
       <h2 id="ligas-title">LIGAS</h2>
       <div class="league-grid">
-        <article class="league-card modal-trigger neon-border" role="button" tabindex="0" aria-haspopup="dialog" aria-controls="pes6-panel" data-target="pes6-panel">
+        <article class="league-card sl-card modal-trigger neon-border" role="button" tabindex="0" aria-haspopup="dialog" aria-controls="pes6-panel" data-target="pes6-panel">
           <img class="league-card-banner" src="assets/pes6.jpg" alt="PES 6 - Infinity Patch" />
           <div class="league-card-content">
             <h3>PES 6 – Infinity Patch</h3>
@@ -119,7 +119,7 @@
           </div>
         </article>
 
-        <article class="league-card modal-trigger neon-border" role="button" tabindex="0" aria-haspopup="dialog" aria-controls="sf-panel" data-target="sf-panel">
+        <article class="league-card sl-card modal-trigger neon-border" role="button" tabindex="0" aria-haspopup="dialog" aria-controls="sf-panel" data-target="sf-panel">
           <img id="kofCardImage" class="league-card-banner" src="assets/kof2002.jpg" alt="King of Fighters 2002 - Fightcade" />
           <div class="league-card-content">
             <h3 id="kofCardHeading">—</h3>
@@ -130,9 +130,9 @@
     </section>
 
     <section class="section hud-separator" aria-labelledby="sponsor-title">
-      <h2 id="sponsor-title" class="neon-text">SPONSOR OFICIAL</h2>
+      <h2 id="sponsor-title" class="neon-text sl-section-title">SPONSOR OFICIAL</h2>
       <div class="league-grid">
-        <a class="league-card sponsor-card neon-border" href="https://www.instagram.com/kelokoclothing.ok?igsh=cHI3ZGV4M2x2M3Zo" target="_blank" rel="noopener noreferrer" aria-label="Ir a la tienda de KELOKO CLOTHING en Instagram">
+        <a class="league-card sl-card sponsor-card neon-border" href="https://www.instagram.com/kelokoclothing.ok?igsh=cHI3ZGV4M2x2M3Zo" target="_blank" rel="noopener noreferrer" aria-label="Ir a la tienda de KELOKO CLOTHING en Instagram">
           <img class="league-card-banner" src="assets/sponsor.jpg" alt="Banner de KELOKO CLOTHING" />
           <div class="league-card-content">
             <h3>KELOKO CLOTHING</h3>
@@ -142,7 +142,7 @@
             <p class="sponsor-description">Keloko Clothing se encarga íntegramente de la producción, los envíos y todo lo relacionado al premio, garantizando que cada campeón reciba su reconocimiento de manera directa y sin intermediarios.</p>
             <p class="sponsor-description">Desde Sudaka League agradecemos profundamente su colaboración y compromiso con la comunidad, y destacamos la importancia de apoyar a los emprendimientos que nacen dentro de la propia liga.</p>
             <p class="sponsor-description">Incentivamos a Keloko Clothing a continuar desarrollando su negocio, y nos enorgullece contar con su apoyo como sponsor oficial.</p>
-            <span class="sponsor-cta">Ir a la tienda</span>
+            <span class="sponsor-cta sl-pill">Ir a la tienda</span>
           </div>
         </a>
       </div>
@@ -150,7 +150,7 @@
 
     <section class="section hud-separator" aria-labelledby="sistema-liga-title">
       <article
-        class="panel-section system-panel-trigger modal-trigger neon-border"
+        class="panel-section sl-card system-panel-trigger modal-trigger neon-border"
         role="button"
         tabindex="0"
         aria-haspopup="dialog"
@@ -158,7 +158,7 @@
         data-target="sistema-panel"
       >
         <div class="system-panel-header">
-          <h2 id="sistema-liga-title" class="neon-text">SISTEMA DE LIGA</h2>
+          <h2 id="sistema-liga-title" class="neon-text sl-section-title">SISTEMA DE LIGA</h2>
           <span class="system-panel-indicator" aria-hidden="true">↗</span>
         </div>
         <p class="system-panel-hint">Click para ver reglas</p>
@@ -166,8 +166,8 @@
       </article>
     </section>
 
-    <section class="section faq" aria-labelledby="faq-title">
-      <h2 id="faq-title" class="neon-text">FAQ</h2>
+    <section class="section faq sl-card" aria-labelledby="faq-title">
+      <h2 id="faq-title" class="neon-text sl-section-title">FAQ</h2>
       <details>
         <summary>¿Hay horarios fijos?</summary>
         <p>No. Se juega cuando coinciden dos jugadores disponibles.</p>
@@ -194,8 +194,8 @@
       </details>
     </section>
 
-    <section class="section panel-section hud-separator about-section" aria-labelledby="que-es-title">
-      <h2 id="que-es-title" class="neon-text">¿QUÉ ES SUDAKA LEAGUE?</h2>
+    <section class="section panel-section sl-card hud-separator sl-divider about-section" aria-labelledby="que-es-title">
+      <h2 id="que-es-title" class="neon-text sl-section-title">¿QUÉ ES SUDAKA LEAGUE?</h2>
       <p>
         Sudaka League es una comunidad de juegos retro online llevados a un formato competitivo. No hay horarios fijos:
         los partidos se juegan cuando coinciden dos jugadores disponibles. La coordinación se realiza por WhatsApp y los
@@ -203,8 +203,8 @@
       </p>
     </section>
 
-    <section id="donaciones" class="section panel-section hud-separator donations-section neon-border" aria-labelledby="donaciones-title">
-      <h2 id="donaciones-title" class="neon-text">💙 Apoyá Sudaka League</h2>
+    <section id="donaciones" class="section panel-section sl-card hud-separator sl-divider donations-section neon-border" aria-labelledby="donaciones-title">
+      <h2 id="donaciones-title" class="neon-text sl-section-title">💙 Apoyá Sudaka League</h2>
       <p class="donation-copy">Sudaka League es un proyecto independiente, sostenido a pulmón y pensado para la comunidad.
 
 Las donaciones serán destinadas a:
@@ -233,10 +233,10 @@ Más interacción y estadísticas
       </div>
 
       <div class="hero-actions donation-actions">
-        <a class="btn btn-primary neon-box" href="https://cafecito.app/sudakaleague" target="_blank" rel="noopener noreferrer">DONAR</a>
+        <a class="btn sl-btn btn-primary neon-box" href="https://cafecito.app/sudakaleague" target="_blank" rel="noopener noreferrer">DONAR</a>
       </div>
 
-      <article id="donacion-transferencia" class="donation-transfer-card neon-border" aria-labelledby="donacion-transfer-title">
+      <article id="donacion-transferencia" class="donation-transfer-card sl-card neon-border" aria-labelledby="donacion-transfer-title">
         <h3 id="donacion-transfer-title">Datos para transferir</h3>
         <p class="donation-transfer-item"><strong>CVU:</strong> <span id="donation-cvu">0000003100040000000001</span></p>
         <p class="donation-transfer-item"><strong>Alias:</strong> <span id="donation-alias">sudaka.league</span></p>
@@ -246,18 +246,18 @@ Más interacción y estadísticas
   </main>
 
   <div id="modal-overlay" class="modal-overlay" hidden>
-    <section id="pes6-panel" class="league-modal" role="dialog" aria-modal="true" aria-labelledby="pes6-modal-title" hidden>
-      <button class="close-btn" type="button" aria-label="Cerrar panel">×</button>
+    <section id="pes6-panel" class="league-modal sl-card" role="dialog" aria-modal="true" aria-labelledby="pes6-modal-title" hidden>
+      <button class="close-btn sl-pill" type="button" aria-label="Cerrar panel">×</button>
       <img class="modal-banner" src="assets/pes6.jpg" alt="PES 6 Banner" />
       <h2 id="pes6-modal-title">PES 6 – INFINITY PATCH</h2>
 
       <div class="tab-bar" role="tablist" aria-label="Contenido de PES 6">
-        <button class="tab-btn is-active" type="button" role="tab" aria-selected="true" aria-controls="pes6-tab-necesitas" id="pes6-tab-btn-necesitas" data-tab="pes6-tab-necesitas">Qué necesitás para jugar</button>
-        <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-sistema" id="pes6-tab-btn-sistema" data-tab="pes6-tab-sistema">Sistema de liga</button>
-        <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-temporadas" id="pes6-tab-btn-temporadas" data-tab="pes6-tab-temporadas">Temporadas</button>
-        <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-palmares" id="pes6-tab-btn-palmares" data-tab="pes6-tab-palmares">Palmarés / Campeones</button>
-        <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-history" id="pes6-tab-btn-history" data-tab="pes6-tab-history">Historial</button>
-        <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-ranking" id="pes6-tab-btn-ranking" data-tab="pes6-tab-ranking">Ranking de títulos</button>
+        <button class="tab-btn sl-tab is-active" type="button" role="tab" aria-selected="true" aria-controls="pes6-tab-necesitas" id="pes6-tab-btn-necesitas" data-tab="pes6-tab-necesitas">Qué necesitás para jugar</button>
+        <button class="tab-btn sl-tab" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-sistema" id="pes6-tab-btn-sistema" data-tab="pes6-tab-sistema">Sistema de liga</button>
+        <button class="tab-btn sl-tab" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-temporadas" id="pes6-tab-btn-temporadas" data-tab="pes6-tab-temporadas">Temporadas</button>
+        <button class="tab-btn sl-tab" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-palmares" id="pes6-tab-btn-palmares" data-tab="pes6-tab-palmares">Palmarés / Campeones</button>
+        <button class="tab-btn sl-tab" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-history" id="pes6-tab-btn-history" data-tab="pes6-tab-history">Historial</button>
+        <button class="tab-btn sl-tab" type="button" role="tab" aria-selected="false" aria-controls="pes6-tab-ranking" id="pes6-tab-btn-ranking" data-tab="pes6-tab-ranking">Ranking de títulos</button>
       </div>
 
       <div class="tab-content">
@@ -310,7 +310,7 @@ Una vez que están registrados, el último paso sería descargar el selector de 
 Una vez instalado lo ejecutan como administrador seleccionan pes6comunidad y apretan en salir
 
 UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES6</textarea>
-            <button class="btn btn-secondary copy-btn" type="button" data-copy-target="pes6-message">📋 Copiar mensaje</button>
+            <button class="btn sl-btn btn-secondary copy-btn" type="button" data-copy-target="pes6-message">📋 Copiar mensaje</button>
           </div>
         </section>
 
@@ -347,15 +347,15 @@ UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES
 
     </section>
 
-    <section id="sf-panel" class="league-modal" role="dialog" aria-modal="true" aria-labelledby="kofModalTitle" hidden>
-      <button class="close-btn" type="button" aria-label="Cerrar panel">×</button>
+    <section id="sf-panel" class="league-modal sl-card" role="dialog" aria-modal="true" aria-labelledby="kofModalTitle" hidden>
+      <button class="close-btn sl-pill" type="button" aria-label="Cerrar panel">×</button>
       <img id="kofModalBanner" class="modal-banner" src="assets/kof2002.jpg" alt="King of Fighters 2002 Banner" />
       <h2 id="kofModalTitle">—</h2>
 
       <div id="kofModalTabsLabel" class="tab-bar" role="tablist" aria-label="Contenido de King of Fighters 2002">
-        <button class="tab-btn is-active" type="button" role="tab" aria-selected="true" aria-controls="sf-tab-necesitas" id="sf-tab-btn-necesitas" data-tab="sf-tab-necesitas">Qué necesitás para jugar</button>
-        <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="sf-tab-sistema" id="sf-tab-btn-sistema" data-tab="sf-tab-sistema">Sistema de liga</button>
-        <button class="tab-btn" type="button" role="tab" aria-selected="false" aria-controls="sf-tab-temporadas" id="sf-tab-btn-temporadas" data-tab="sf-tab-temporadas">Temporadas</button>
+        <button class="tab-btn sl-tab is-active" type="button" role="tab" aria-selected="true" aria-controls="sf-tab-necesitas" id="sf-tab-btn-necesitas" data-tab="sf-tab-necesitas">Qué necesitás para jugar</button>
+        <button class="tab-btn sl-tab" type="button" role="tab" aria-selected="false" aria-controls="sf-tab-sistema" id="sf-tab-btn-sistema" data-tab="sf-tab-sistema">Sistema de liga</button>
+        <button class="tab-btn sl-tab" type="button" role="tab" aria-selected="false" aria-controls="sf-tab-temporadas" id="sf-tab-btn-temporadas" data-tab="sf-tab-temporadas">Temporadas</button>
       </div>
 
       <div class="tab-content">
@@ -376,7 +376,7 @@ UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES
 
           <div class="copy-box">
             <textarea id="kof-message" readonly>Mensaje automático de bienvenida</textarea>
-            <button class="btn btn-secondary copy-btn" type="button" data-copy-target="kof-message">📋 Copiar mensaje</button>
+            <button class="btn sl-btn btn-secondary copy-btn" type="button" data-copy-target="kof-message">📋 Copiar mensaje</button>
           </div>
         </section>
 
@@ -389,16 +389,16 @@ UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES
         </section>
       </div>
 
-      <a id="wa-sf-modal" class="btn btn-primary neon-box" href="#" target="_blank" rel="noopener noreferrer">Unirme a la comunidad</a>
+      <a id="wa-sf-modal" class="btn sl-btn btn-primary neon-box" href="#" target="_blank" rel="noopener noreferrer">Unirme a la comunidad</a>
     </section>
 
-    <section id="sistema-panel" class="league-modal system-modal" role="dialog" aria-modal="true" aria-labelledby="sistema-panel-title" hidden>
-      <button class="close-btn" type="button" aria-label="Cerrar panel">×</button>
+    <section id="sistema-panel" class="league-modal sl-card system-modal" role="dialog" aria-modal="true" aria-labelledby="sistema-panel-title" hidden>
+      <button class="close-btn sl-pill" type="button" aria-label="Cerrar panel">×</button>
       <h2 id="sistema-panel-title">SISTEMA DE LIGA</h2>
 
       <div class="tab-bar system-tab-bar" role="tablist" aria-label="Sistema por liga">
-        <button class="tab-btn system-tab-btn is-active" type="button" role="tab" aria-selected="true" aria-controls="sistema-tab-pes6" id="sistema-tab-btn-pes6" data-tab="sistema-tab-pes6">PES 6 – Infinity Patch</button>
-        <button class="tab-btn system-tab-btn" type="button" role="tab" aria-selected="false" aria-controls="sistema-tab-sfii" id="sistema-tab-btn-sfii" data-tab="sistema-tab-sfii">—</button>
+        <button class="tab-btn sl-tab system-tab-btn is-active" type="button" role="tab" aria-selected="true" aria-controls="sistema-tab-pes6" id="sistema-tab-btn-pes6" data-tab="sistema-tab-pes6">PES 6 – Infinity Patch</button>
+        <button class="tab-btn sl-tab system-tab-btn" type="button" role="tab" aria-selected="false" aria-controls="sistema-tab-sfii" id="sistema-tab-btn-sfii" data-tab="sistema-tab-sfii">—</button>
       </div>
 
       <div class="tab-content">

--- a/styles-v2.css
+++ b/styles-v2.css
@@ -190,6 +190,27 @@ a {
   text-shadow: var(--neon-text-shadow);
 }
 
+.sl-section-title {
+  text-shadow: var(--neon-text-shadow);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.sl-divider {
+  position: relative;
+}
+
+.sl-divider::after {
+  content: "";
+  position: absolute;
+  left: 6%;
+  right: 6%;
+  bottom: -0.45rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--line), transparent);
+  box-shadow: var(--divider-glow), 0 0 14px -10px rgba(88, 201, 255, 0.9);
+}
+
 @keyframes neonPulse {
   0%,
   100% {
@@ -251,6 +272,8 @@ a {
 }
 
 .btn,
+.sl-btn,
+.sl-pill,
 .sponsor-cta,
 .pes6-ranking-toggle,
 .history-accordion-trigger,
@@ -260,7 +283,9 @@ a {
   transition: border-color 180ms ease, box-shadow 180ms ease, background-color 180ms ease, transform 180ms ease;
 }
 
-.btn {
+.btn,
+.sl-btn,
+.sl-pill {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -293,8 +318,14 @@ a {
 }
 
 .btn:hover,
+.sl-btn:hover,
+.sl-pill:hover,
 .btn:focus-visible,
+.sl-btn:focus-visible,
+.sl-pill:focus-visible,
 .btn:active,
+.sl-btn:active,
+.sl-pill:active,
 .sponsor-cta:hover,
 .sponsor-cta:focus-visible,
 .sponsor-cta:active,
@@ -315,12 +346,16 @@ a {
 }
 
 .btn:active,
+.sl-btn:active,
+.sl-pill:active,
 .tab-btn:active,
 .cup-tab-btn:active {
   transform: translateY(1px);
 }
 
 .btn[disabled],
+.sl-btn[disabled],
+.sl-pill[disabled],
 .btn:disabled {
   opacity: 0.46;
   cursor: not-allowed;
@@ -328,6 +363,8 @@ a {
 }
 
 .btn:focus-visible,
+.sl-btn:focus-visible,
+.sl-pill:focus-visible,
 .league-card:focus-visible,
 .system-panel-trigger:focus-visible,
 summary:focus-visible,
@@ -354,6 +391,21 @@ summary:focus-visible,
   box-shadow: var(--divider-glow), 0 0 14px -10px rgba(88, 201, 255, 0.9);
 }
 
+
+.sl-card {
+  border: 1px solid rgba(88, 201, 255, 0.24);
+  box-shadow: var(--neon-border-shadow);
+  border-radius: var(--radius-md);
+  background: var(--bg-card-strong);
+  padding: 0.95rem;
+}
+
+.sl-card:hover,
+.sl-card:focus-visible {
+  border-color: rgba(88, 201, 255, 0.52);
+  box-shadow: var(--neon-box-shadow-hover);
+}
+
 .panel-section,
 .faq,
 .league-card,
@@ -367,6 +419,7 @@ summary:focus-visible,
   box-shadow: var(--neon-border-shadow), var(--shadow-card);
   background: linear-gradient(180deg, rgba(22, 33, 51, 0.95), rgba(13, 22, 35, 0.95));
 }
+
 
 .panel-section,
 .faq,
@@ -693,6 +746,11 @@ summary:focus-visible,
   border-radius: 14px;
 }
 
+.pes6-ranking-row.is-top {
+  border-color: rgba(88, 201, 255, 0.72);
+  box-shadow: 0 0 0 1px rgba(88, 201, 255, 0.35), 0 0 20px -8px rgba(88, 201, 255, 0.66);
+}
+
 .palmares-trophy,
 .history-trophy {
   width: 40px;
@@ -702,6 +760,8 @@ summary:focus-visible,
 
 .palmares-subtitle,
 .pes6-ranking-subtitle,
+.history-section h4,
+.history-label,
 .cup-history-heading,
 .cup-history-title,
 .cup-round-title {
@@ -751,7 +811,8 @@ summary:focus-visible,
 }
 
 .cup-tab-btn,
-.tab-btn {
+.tab-btn,
+.sl-tab {
   border: 1px solid var(--line);
   border-radius: 0.75rem;
   background: rgba(11, 20, 33, 0.82);
@@ -763,7 +824,9 @@ summary:focus-visible,
 }
 
 .cup-tab-btn.is-active,
-.tab-btn.is-active {
+.tab-btn.is-active,
+.sl-tab.is-active,
+.sl-tab[aria-selected="true"] {
   border-color: rgba(88, 201, 255, 0.72);
   background: rgba(88, 201, 255, 0.14);
   box-shadow: var(--neon-box-shadow-hover);
@@ -986,7 +1049,9 @@ summary:focus-visible,
 }
 
 .pes6-ranking-toggle,
-.history-accordion-trigger {
+.history-accordion-trigger,
+.sl-pill,
+.sl-btn {
   border: 1px solid var(--line);
   border-radius: 0.7rem;
   background: rgba(7, 14, 25, 0.82);


### PR DESCRIPTION
### Motivation
- Unificar la estética existente (bordes neon, glow, cards glassy, botones pill) en todas las secciones reutilizando exactamente los valores ya presentes en el CSS actual. 
- Mantener la identidad tipográfica y el contenido sin cambios, tomando como referencia las secciones que ya se ven bien (Ranking, Estado de Temporada). 
- Proveer un conjunto de utilidades reutilizables para aplicar el mismo look a contenidos estáticos y generados dinámicamente.

### Description
- Se añadieron clases globales en `styles-v2.css`: `sl-section-title`, `sl-divider`, `sl-card`, `sl-btn` / `sl-pill` y `sl-tab`, copiando valores reales existentes (colores, bordes, sombras, glow) para garantizar idéntico aspecto. 
- Se aplicaron esas clases en `index.html` a las secciones principales y modales (Estado de Temporada, Copa Interdivisional, Ligas, Sponsor, Sistema de liga, FAQ, About, Donaciones y modales PES6 / KOF) para homogeneizar headers, cards, botones y tabs. 
- Se actualizaron los renderizadores dinámicos en `app.js` para que las tarjetas/filas/paneles generados (Palmarés, Historial, Ranking) usen `sl-card`, `sl-pill`, `sl-btn` y se añadió la clase `is-top` para resaltar la posición #1 sin alterar estructura ni datos. 
- No se modificaron fuentes ni `font-family` y no se añadieron imports externos; todos los valores reutilizan variables y reglas ya definidas en el CSS existente.

### Testing
- Se ejecutó `node --check app.js` para validar la sintaxis del bundle de JS y la comprobación fue exitosa. 
- Se ejecutó `git diff --check` para detectar problemas de formato/espacios y la verificación fue exitosa. 
- Intenté generar una captura con Playwright (`http.server` + navegador) como validación visual automática pero falló por limitaciones del entorno (browser/server), por lo que no se pudo obtener screenshot automatizado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c6c0fb798833294cb7ce311e2db39)