### PR TITLE
Rediseño visual gamer: reemplazo completo de styles.css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,412 +1,123 @@
-:root {
-  --bg-main: #030814;
-  --bg-panel: rgba(10, 22, 46, 0.82);
-  --bg-elevated: #0c1b39;
-  --text-main: #e8f1ff;
-  --text-soft: #b8c6ea;
-  --line: rgba(84, 164, 255, 0.5);
-  --line-strong: rgba(99, 184, 255, 0.9);
-  --glow: 0 0 0.7rem rgba(89, 173, 255, 0.45);
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700;800&family=Rajdhani:wght@400;600;700&display=swap');
+
+:root{
+  --bg-main: #050c1f;
+  --bg-panel: #0b1835;
+  --bg-card: #0f2247;
+  --text-main: #e8f4ff;
+  --text-soft: #8fb3ff;
+  --neon: #3ea6ff;
+  --neon-strong: #69c8ff;
+  --purple: #8b5cf6;
+  --line: rgba(80,160,255,0.25);
 }
 
-* {
-  box-sizing: border-box;
-}
-
-html {
-  scroll-behavior: smooth;
-}
-
-body {
-  margin: 0;
-  font-family: "Inter", system-ui, sans-serif;
+body{
+  margin:0;
+  background: linear-gradient(180deg,#050c1f 0%, #081634 100%);
   color: var(--text-main);
-  background: radial-gradient(circle at 20% 0%, #13254d 0%, #050a17 40%, #03060f 100%);
-  min-height: 100vh;
-  overflow-x: hidden;
+  font-family: 'Rajdhani', sans-serif;
 }
 
-body.no-scroll {
-  overflow: hidden;
-}
-
-.bg-effects {
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: -1;
-  background-image:
-    radial-gradient(circle at 20% 30%, rgba(99, 179, 255, 0.15) 0 2px, transparent 2px),
-    radial-gradient(circle at 75% 20%, rgba(99, 179, 255, 0.18) 0 1px, transparent 1px),
-    repeating-linear-gradient(90deg, transparent 0 32px, rgba(59, 104, 163, 0.1) 33px),
-    linear-gradient(to bottom, rgba(75, 130, 210, 0.07), transparent 24%);
-  opacity: 0.85;
-}
-
-.section {
-  width: min(1100px, 92%);
-  margin: 0 auto;
-  padding: 2.8rem 0;
-}
-
-h1,
-h2,
-h3,
-.hero-kicker {
-  font-family: "Orbitron", "Inter", sans-serif;
-  letter-spacing: 0.018em;
-}
-
-h2 {
-  margin: 0 0 1rem;
-  font-size: clamp(1.15rem, 3.15vw, 1.68rem);
-  line-height: 1.14;
-  text-shadow: var(--glow);
-  overflow-wrap: anywhere;
-  word-break: break-word;
-}
-
-.hero {
-  text-align: center;
-  padding-top: 4.2rem;
-}
-
-.hero-kicker {
-  margin: 0;
-  font-size: 0.78rem;
-  color: #90bbff;
+h1,h2,h3,.section-title{
+  font-family: 'Orbitron', sans-serif;
+  letter-spacing: 2px;
   text-transform: uppercase;
+  text-shadow: 0 0 10px rgba(62,166,255,0.4);
 }
 
-.hero h1 {
-  margin: 0.8rem 0 0.5rem;
-  font-size: clamp(2.2rem, 13vw, 5.8rem);
-  line-height: 1;
-  text-shadow: 0 0 1rem rgba(70, 148, 255, 0.65);
-}
+/* CARDS */
 
-.subtitle,
-.hero-copy {
-  margin: 0 auto;
-  max-width: 740px;
-  color: var(--text-soft);
-}
-
-.subtitle {
-  font-weight: 700;
-  margin-bottom: 0.8rem;
-}
-
-.hero-actions {
-  display: flex;
-  gap: 0.8rem;
-  justify-content: center;
-  flex-wrap: wrap;
-  margin-top: 1.4rem;
-}
-
-.btn {
+.card,
+.season-card,
+.ranking-card{
+  background: linear-gradient(180deg,#0b1835,#0f2247);
   border: 1px solid var(--line);
-  color: #ddedff;
-  text-decoration: none;
-  background: rgba(27, 58, 107, 0.28);
-  padding: 0.72rem 1.05rem;
-  border-radius: 0.7rem;
-  font-weight: 700;
-  cursor: pointer;
-  transition: transform 180ms ease, box-shadow 220ms ease, border-color 220ms ease;
+  border-radius: 18px;
+  padding: 20px;
+  box-shadow:
+    0 0 0 1px rgba(62,166,255,0.1),
+    0 0 20px rgba(62,166,255,0.08);
+  transition: 0.3s ease;
 }
 
-.btn:hover,
-.btn:focus-visible {
-  transform: translateY(-2px);
-  border-color: var(--line-strong);
-  box-shadow: var(--glow), 0 0 1.2rem rgba(90, 170, 255, 0.3);
+.card:hover,
+.season-card:hover,
+.ranking-card:hover{
+  box-shadow:
+    0 0 0 1px rgba(62,166,255,0.2),
+    0 0 25px rgba(62,166,255,0.15);
 }
 
-.btn:focus-visible,
-.league-card:focus-visible,
-summary:focus-visible,
-.close-btn:focus-visible {
-  outline: 2px solid #8ec5ff;
-  outline-offset: 2px;
+/* BOTONES */
+
+button,
+.btn{
+  background: linear-gradient(90deg,#0f2247,#112a5e);
+  border: 1px solid rgba(62,166,255,0.3);
+  border-radius: 30px;
+  color: var(--text-main);
+  padding: 10px 22px;
+  font-family: 'Orbitron', sans-serif;
+  letter-spacing: 1px;
+  transition: 0.3s ease;
 }
 
-.btn-primary {
-  background: linear-gradient(180deg, rgba(58, 121, 218, 0.4), rgba(14, 36, 74, 0.75));
+button:hover,
+.btn:hover{
+  box-shadow: 0 0 12px rgba(62,166,255,0.6);
+  border-color: var(--neon-strong);
 }
 
-.btn-secondary {
-  background: rgba(6, 18, 38, 0.72);
+/* STATUS BADGES */
+
+.badge-active{
+  background: linear-gradient(90deg,#00c2ff,#3ea6ff);
+  color:#00101f;
+  font-weight:700;
+  border-radius:20px;
+  padding:6px 14px;
+  box-shadow:0 0 10px rgba(62,166,255,0.5);
 }
 
-.panel-section,
-.faq,
-.league-card,
-.league-modal {
-  background: var(--bg-panel);
-  border: 1px solid rgba(92, 163, 250, 0.35);
-  border-radius: 1rem;
-  box-shadow: inset 0 0 0 1px rgba(52, 93, 155, 0.2), 0 12px 40px rgba(3, 8, 19, 0.55);
-  backdrop-filter: blur(4px);
+.badge-wait{
+  background: linear-gradient(90deg,#7c3aed,#a855f7);
+  color:white;
+  border-radius:20px;
+  padding:6px 14px;
+  box-shadow:0 0 10px rgba(168,85,247,0.5);
 }
 
-.hud-separator {
-  position: relative;
+/* RANKING DE TITULOS */
+
+.ranking-item{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding:16px;
+  margin-bottom:14px;
+  background: linear-gradient(180deg,#0d1c3d,#0f2247);
+  border:1px solid var(--line);
+  border-radius:16px;
+  box-shadow:0 0 15px rgba(62,166,255,0.08);
 }
 
-.hud-separator::after {
-  content: "";
-  position: absolute;
-  left: 8%;
-  right: 8%;
-  bottom: -0.35rem;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(99, 184, 255, 0.9), transparent);
+.ranking-position{
+  font-family:'Orbitron', sans-serif;
+  font-size:20px;
+  color: var(--neon-strong);
+  text-shadow:0 0 8px rgba(62,166,255,0.6);
 }
 
-.panel-section,
-.faq {
-  padding: clamp(2.25rem, 5.6vw, 3.1rem);
+.ranking-titles{
+  font-size:26px;
+  font-weight:700;
+  color:white;
 }
 
-.panel-section h2,
-.faq h2,
-.league-modal h2,
-.league-card-content h3,
-.league-modal h3 {
-  letter-spacing: 0.012em;
-  line-height: 1.14;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-  hyphens: auto;
-}
+/* TITULOS SECCION */
 
-.panel-section h2,
-.faq h2,
-.league-modal h2 {
-  font-size: clamp(1.08rem, 2.85vw, 1.48rem);
-}
-
-.league-card-content h3,
-.league-modal h3 {
-  font-size: clamp(0.95rem, 2.35vw, 1.15rem);
-}
-
-
-.panel-section h2 {
-  margin-bottom: 1.2rem;
-  padding-inline: clamp(0.3rem, 1.2vw, 0.55rem);
-}
-
-.panel-section p,
-.panel-section li {
-  line-height: 1.62;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-}
-
-.league-grid {
-  display: grid;
-  gap: 1rem;
-}
-
-.league-card {
-  overflow: hidden;
-  cursor: pointer;
-  transition: transform 180ms ease, box-shadow 220ms ease;
-}
-
-.league-card:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 0 1.5rem rgba(99, 184, 255, 0.25);
-}
-
-.league-card-banner,
-.modal-banner {
-  width: 100%;
-  height: 220px;
-  object-fit: cover;
-  display: block;
-}
-
-.league-card-banner {
-  border-top-left-radius: 1rem;
-  border-top-right-radius: 1rem;
-}
-
-.league-card-content {
-  padding: clamp(1.3rem, 3.6vw, 1.65rem);
-}
-
-.feature-list {
-  padding-left: 1.2rem;
-  margin: 0;
-}
-
-.feature-list li {
-  margin-bottom: 0.45rem;
-}
-
-.whatsapp-grid {
-  display: grid;
-  gap: 0.8rem;
-}
-
-.btn-large {
-  text-align: center;
-  padding: 1rem;
-  font-size: 1rem;
-}
-
-.faq details {
-  border: 1px solid rgba(90, 151, 228, 0.3);
-  border-radius: 0.75rem;
-  padding: clamp(0.95rem, 2.5vw, 1.15rem);
-  background: rgba(8, 24, 51, 0.6);
-  margin-bottom: 0.6rem;
-}
-
-.faq summary {
-  font-weight: 700;
-  cursor: pointer;
-}
-
-.faq p {
-  color: var(--text-soft);
-}
-
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(2, 8, 20, 0.78);
-  z-index: 20;
-  padding: 1rem;
-  display: grid;
-  place-items: center;
-}
-
-.league-modal {
-  width: min(900px, 95vw);
-  max-height: 92vh;
-  overflow-y: auto;
-  padding: clamp(1.5rem, 4.1vw, 2.05rem);
-  position: relative;
-  animation: modal-in 220ms ease;
-}
-
-@keyframes modal-in {
-  from {
-    opacity: 0;
-    transform: translateY(18px) scale(0.98);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-.close-btn {
-  position: absolute;
-  top: 0.75rem;
-  right: 0.75rem;
-  border: 1px solid var(--line);
-  color: #e5f3ff;
-  background: rgba(4, 13, 28, 0.9);
-  font-size: 1.5rem;
-  line-height: 1;
-  border-radius: 0.4rem;
-  width: 2rem;
-  height: 2rem;
-  cursor: pointer;
-}
-
-.copy-box textarea {
-  width: 100%;
-  min-height: 230px;
-  resize: vertical;
-  padding: 0.8rem;
-  color: #dfeeff;
-  font-family: "Inter", sans-serif;
-  border-radius: 0.8rem;
-  border: 1px solid rgba(113, 182, 255, 0.35);
-  background: rgba(5, 19, 39, 0.8);
-}
-
-.copy-btn {
-  margin-top: 0.65rem;
-}
-
-.back-to-top {
-  position: fixed;
-  right: 0.9rem;
-  bottom: 1rem;
-  z-index: 10;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.back-to-top.visible {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-
-@media (max-width: 759px) {
-  .panel-section,
-  .faq {
-    padding: clamp(2.25rem, 8vw, 2.85rem);
-  }
-
-  .panel-section h2 {
-    margin-bottom: 1.05rem;
-    padding-inline: 0.45rem;
-  }
-}
-
-@media (min-width: 760px) {
-  .section {
-    padding: 3.2rem 0;
-  }
-
-  .panel-section,
-  .faq {
-    padding: clamp(2.5rem, 4vw, 3.1rem);
-  }
-
-  .league-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .whatsapp-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .league-card img,
-  .modal-banner {
-    height: 260px;
-  }
-
-  .league-modal {
-    padding: 1.85rem;
-  }
-}
-
-.modal-overlay[hidden],
-.league-modal[hidden] {
-  display: none !important;
-}
-/* ===== League card banner images ===== */
-.league-card-banner{
-  width: 100%;
-  height: 230px;
-  display: block;
-  object-fit: cover;
-  object-position: center;
-  border-radius: 16px 16px 0 0;
-}
-
-/* Para que no se recorte raro dentro de la card */
-.league-card{
-  overflow: hidden;
+.section-title{
+  margin-bottom:20px;
+  font-size:22px;
 }


### PR DESCRIPTION
### Motivation
- Aplicar un rediseño visual competitivo gamer elegante sin tocar la estructura HTML ni JavaScript, manteniendo la barra superior y los logos actuales.
- Sustituir el tema existente por una paleta azul profunda con neon controlado y glow suave para títulos y cards, y conservar el ranking de títulos visual como en el diseño anterior.
- Centralizar variables de color y tipografías tecnológicas (Orbitron / Rajdhani) para consistencia visual en cards, botones y badges.

### Description
- Reemplacé por completo el contenido de `styles.css` con la nueva hoja que importa `Orbitron` y `Rajdhani` y define tokens CSS (`--bg-main`, `--neon`, `--neon-strong`, etc.).
- Rediseñé estilos clave: cards (`.card`, `.season-card`, `.ranking-card`), botones (`button`, `.btn`), badges (`.badge-active`, `.badge-wait`) y ranking (`.ranking-item`, `.ranking-position`, `.ranking-titles`) usando gradientes, glow suave y bordes redondeados.
- No se modificó ningún archivo HTML o JS; el cambio afecta únicamente a `styles.css` para respetar la restricción de no tocar la estructura funcional.

### Testing
- Verifiqué el diff con `git diff -- styles.css` y confirmé que `styles.css` fue completamente reemplazado antes de commitear.
- Levanté un servidor estático con `python3 -m http.server 4173` y capturé una captura de pantalla con Playwright produciendo `artifacts/redesign-home.png` para revisión visual.
- Ejecuté `git commit` y la operación completó correctamente (registro de cambios: `1 file changed, 92 insertions(+), 381 deletions(-)`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c7c5886d0833299d36d0ff2832320)