### PR TITLE
Ajusta look arcade sobrio del panel Ranking de títulos en styles-v2.css

### DIFF
--- a/styles-v2.css
+++ b/styles-v2.css
@@ -459,7 +459,7 @@ summary:focus-visible,
 .pes6-ranking-list-wrap {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
 }
 
 .history-layout {
@@ -751,16 +751,16 @@ summary:focus-visible,
   height: auto;
   max-height: none;
   overflow: hidden;
-  padding: 14px;
-  border-radius: 14px;
-  border-color: rgba(99, 196, 255, 0.26);
-  background: linear-gradient(180deg, rgba(13, 26, 43, 0.9), rgba(8, 17, 30, 0.9));
-  box-shadow: 0 0 0 1px rgba(99, 196, 255, 0.1), 0 14px 26px rgba(0, 0, 0, 0.28);
+  padding: 16px 18px;
+  border-radius: 16px;
+  border-color: rgba(119, 210, 255, 0.33);
+  background: linear-gradient(180deg, rgba(17, 36, 62, 0.94), rgba(10, 22, 40, 0.95));
+  box-shadow: 0 0 0 1px rgba(119, 210, 255, 0.13), 0 0 18px -13px rgba(119, 210, 255, 0.45), 0 14px 24px rgba(0, 0, 0, 0.3);
 }
 
 .pes6-ranking-row.is-top {
-  border-color: rgba(99, 196, 255, 0.5);
-  box-shadow: 0 0 0 1px rgba(99, 196, 255, 0.26), 0 0 16px -9px rgba(99, 196, 255, 0.42), 0 12px 24px rgba(0, 0, 0, 0.3);
+  border-color: rgba(119, 210, 255, 0.54);
+  box-shadow: 0 0 0 1px rgba(119, 210, 255, 0.22), 0 0 20px -12px rgba(119, 210, 255, 0.5), 0 12px 24px rgba(0, 0, 0, 0.3);
 }
 
 .palmares-trophy,
@@ -997,9 +997,11 @@ summary:focus-visible,
 .pes6-ranking-header,
 .rankingHeaderRow {
   display: grid;
-  grid-template-columns: 52px minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-areas:
+    "left name btn";
   align-items: center;
-  gap: 10px;
+  gap: 14px;
 }
 
 .pes6-ranking-position,
@@ -1010,49 +1012,61 @@ summary:focus-visible,
 
 .pes6-ranking-position,
 .rankingPos {
-  width: 2.3rem;
-  min-height: 2.3rem;
-  display: inline-flex;
+  width: auto;
+  min-height: auto;
+  display: flex;
   align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  border: 1px solid rgba(99, 196, 255, 0.44);
-  background: linear-gradient(180deg, rgba(99, 196, 255, 0.24), rgba(99, 196, 255, 0.08));
-  box-shadow: 0 0 0 1px rgba(99, 196, 255, 0.18), 0 0 14px -10px rgba(99, 196, 255, 0.52);
+  justify-content: flex-start;
+  border-radius: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
   font-family: var(--title-font);
-  font-size: 0.86rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
+  font-size: clamp(1.1rem, 2.4vw, 1.36rem);
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  color: #ccedff;
+  text-shadow: 0 0 10px rgba(99, 196, 255, 0.2);
+  grid-area: left;
+  align-self: end;
 }
 
 .pes6-ranking-player,
 .rankingName {
+  grid-area: name;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: clamp(1rem, 2.6vw, 1.2rem);
+  font-size: clamp(1.08rem, 2.7vw, 1.34rem);
   font-weight: 800;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.07em;
   text-transform: uppercase;
+  text-shadow: 0 0 10px rgba(99, 196, 255, 0.12);
 }
 
 .pes6-ranking-stats {
+  grid-area: left;
+  align-self: start;
   display: flex;
-  align-items: baseline;
-  gap: 0.25rem;
-  color: var(--text-muted);
-  font-size: 0.84rem;
-  letter-spacing: 0.03em;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.04rem;
+  color: rgba(226, 241, 255, 0.9);
+  font-size: 0.74rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  line-height: 1.05;
+  margin-top: 0.08rem;
 }
 
 .pes6-ranking-panel,
 .history-accordion-panel {
   margin-top: 0.65rem;
-  padding: 0.75rem;
-  border-top: 1px solid rgba(99, 196, 255, 0.24);
+  padding: 0.72rem 0.82rem;
+  border: 1px solid rgba(119, 210, 255, 0.26);
   border-radius: 0.8rem;
-  background: rgba(5, 12, 23, 0.76);
+  background: linear-gradient(180deg, rgba(8, 17, 30, 0.88), rgba(6, 13, 24, 0.88));
 }
 
 .pes6-ranking-panel {
@@ -1072,7 +1086,8 @@ summary:focus-visible,
   white-space: normal;
   overflow-wrap: anywhere;
   word-break: break-word;
-  line-height: 1.25;
+  line-height: 1.35;
+  font-size: 0.86rem;
   color: var(--text-muted);
 }
 
@@ -1107,45 +1122,97 @@ summary:focus-visible,
   padding-inline: 1rem;
   justify-self: end;
   font-size: 0.7rem;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .pes6-ranking-total,
 .rankingTotal {
-  font-size: 1.02rem;
-  font-weight: 800;
-  color: var(--text-main);
+  font-size: clamp(1.35rem, 3.6vw, 1.72rem);
+  font-weight: 900;
+  letter-spacing: 0.02em;
+  color: #ecf7ff;
+  line-height: 1;
 }
 
 .pes6-ranking-total-label,
 .rankingMeta {
-  color: var(--text-muted);
+  color: rgba(190, 216, 235, 0.88);
+  font-size: 0.64rem;
+  letter-spacing: 0.14em;
+  font-weight: 700;
+}
+
+.pes6-ranking {
+  border-radius: 20px;
+  border-color: rgba(119, 210, 255, 0.45);
+  background: linear-gradient(180deg, rgba(15, 33, 58, 0.94), rgba(8, 19, 36, 0.96));
+  box-shadow: 0 0 0 1px rgba(119, 210, 255, 0.14), 0 0 22px -13px rgba(119, 210, 255, 0.48), 0 16px 28px rgba(0, 0, 0, 0.34);
+  padding: 1.1rem;
+}
+
+.pes6-ranking > h3 {
+  margin: 0;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  text-shadow: 0 0 11px rgba(99, 196, 255, 0.2);
+}
+
+.pes6-ranking-subtitle {
+  margin: 0.45rem 0 0.9rem;
+  font-size: 0.79rem;
+  letter-spacing: 0.04em;
+  color: rgba(177, 200, 223, 0.9);
+}
+
+.pes6-ranking-row .pes6-ranking-toggle,
+.pes6-ranking-row .rankingBtn {
+  grid-area: btn;
+  align-self: center;
+  min-width: 116px;
+  min-height: 36px;
+  padding-inline: 0.95rem;
+  border-color: rgba(119, 210, 255, 0.5);
+  background: linear-gradient(180deg, rgba(16, 33, 58, 0.94), rgba(10, 21, 39, 0.94));
+  box-shadow: 0 0 0 1px rgba(119, 210, 255, 0.2), 0 0 14px -11px rgba(119, 210, 255, 0.44);
+}
+
+.pes6-ranking-row .pes6-ranking-toggle:hover,
+.pes6-ranking-row .pes6-ranking-toggle:focus-visible {
+  border-color: rgba(150, 223, 255, 0.68);
+  box-shadow: 0 0 0 1px rgba(150, 223, 255, 0.28), 0 0 18px -10px rgba(150, 223, 255, 0.42);
 }
 
 @media (max-width: 420px) {
   .pes6-ranking-header,
   .rankingHeaderRow {
-    grid-template-columns: 44px minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr) auto;
     grid-template-areas:
-      "pos name btn"
-      ". meta btn";
+      "left name"
+      "meta btn";
     grid-auto-rows: auto;
-    row-gap: 6px;
+    row-gap: 8px;
+    column-gap: 10px;
   }
 
   .pes6-ranking-position,
   .rankingPos {
-    grid-area: pos;
+    grid-area: left;
+    align-self: center;
   }
 
   .pes6-ranking-player,
   .rankingName {
     grid-area: name;
+    align-self: center;
+    font-size: 1.04rem;
   }
 
   .pes6-ranking-stats,
   .rankingMeta {
     grid-area: meta;
-    font-size: 12px;
+    margin-top: 0;
+    font-size: 0.68rem;
     opacity: 0.9;
   }
 
@@ -1153,6 +1220,13 @@ summary:focus-visible,
   .rankingBtn {
     grid-area: btn;
     justify-self: end;
+    min-width: 114px;
+    padding-inline: 0.85rem;
+    font-size: 0.66rem;
+  }
+
+  .pes6-ranking-row {
+    padding: 14px;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Recuperar la estética antigua (arcade/gamer sobria) del panel “RANKING DE TÍTULOS” sin tocar datos, lógica JS ni estructura HTML.  
- Aislar los cambios en `styles-v2.css` ya que la página carga estilos desde ese archivo.  
- Mejorar legibilidad y separación de cada fila para que cada item se vea como una card clara y espaciosa.

### Description
- Rediseñé el contenedor `.pes6-ranking` para aplicar un fondo azul oscuro con degradé muy sutil, borde celeste fino, glow controlado y radios más redondeados (18–22px) para el panel principal.  
- Transformé cada fila (`.pes6-ranking-row` y `.pes6-ranking-row.is-top`) en cards separadas con padding mayor, borde/glow leve y sombreado suave para destacar la separación entre items.  
- Reorganicé el layout de la fila usando la grid de `.pes6-ranking-header` (áreas `left name btn`) para mostrar a la izquierda el puesto/contador, en el centro el nombre protagonista y a la derecha el botón pill `Ver detalle`, manteniendo el caret y la lógica actual intactos.  
- Ajusté estilos del bloque expandible (`.pes6-ranking-panel` / `.pes6-ranking-details`) para quedar embutido en la card con borde tenue, fondo consistente y tipografía más chica; y optimicé tipografía (tracking/uppercase) para lograr un feel gamer/arcade sin añadir fuentes externas.  
- Mejoré el comportamiento responsive en `@media (max-width:420px)` para evitar que el botón `Ver detalle` se corte, pasando a una disposición en dos filas cuando aplica y asegurando `min-width`/`white-space: nowrap` en el botón.

### Testing
- Ejecuté la búsqueda de referencias en el proyecto con `rg` para asegurar que los selectores afectados corresponden al ranking y confirmar el alcance (éxito).  
- Levanté un servidor local con `python3 -m http.server 4173` y cargué la página para validar que los assets y `styles-v2.css` se sirven correctamente (éxito).  
- Intenté generar screenshots automáticos con Playwright para desktop y mobile, pero el entorno no pudo lanzar Chromium (error SIGSEGV en `chrome-headless-shell`), por lo que no se generaron capturas automáticas (fallido).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c830d9fc08332ba098f37deca47ba)