### PR TITLE
Fix layout for "Ranking de títulos" rows to prevent overlap and improve responsive alignment

### DIFF
--- a/styles-v2.css
+++ b/styles-v2.css
@@ -756,11 +756,17 @@ summary:focus-visible,
   border-color: rgba(119, 210, 255, 0.33);
   background: linear-gradient(180deg, rgba(17, 36, 62, 0.94), rgba(10, 22, 40, 0.95));
   box-shadow: 0 0 0 1px rgba(119, 210, 255, 0.13), 0 0 18px -13px rgba(119, 210, 255, 0.45), 0 14px 24px rgba(0, 0, 0, 0.3);
+  transition: border-color 180ms ease, box-shadow 180ms ease;
 }
 
 .pes6-ranking-row.is-top {
   border-color: rgba(119, 210, 255, 0.54);
   box-shadow: 0 0 0 1px rgba(119, 210, 255, 0.22), 0 0 20px -12px rgba(119, 210, 255, 0.5), 0 12px 24px rgba(0, 0, 0, 0.3);
+}
+
+.pes6-ranking-row:hover {
+  border-color: rgba(160, 228, 255, 0.62);
+  box-shadow: 0 0 0 1px rgba(160, 228, 255, 0.27), 0 0 22px -12px rgba(119, 210, 255, 0.5), 0 14px 24px rgba(0, 0, 0, 0.32);
 }
 
 .palmares-trophy,
@@ -997,11 +1003,10 @@ summary:focus-visible,
 .pes6-ranking-header,
 .rankingHeaderRow {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  grid-template-areas:
-    "left name btn";
+  grid-template-columns: 56px minmax(0, 1fr) auto 124px;
+  grid-template-areas: "rank name titles btn";
   align-items: center;
-  gap: 14px;
+  gap: 0.75rem;
 }
 
 .pes6-ranking-position,
@@ -1012,23 +1017,22 @@ summary:focus-visible,
 
 .pes6-ranking-position,
 .rankingPos {
-  width: auto;
-  min-height: auto;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  border-radius: 0;
-  border: 0;
-  background: transparent;
-  box-shadow: none;
+  width: 56px;
+  height: 56px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  border: 1px solid rgba(146, 221, 255, 0.54);
+  background: radial-gradient(circle at 35% 30%, rgba(143, 221, 255, 0.27), rgba(17, 35, 58, 0.97) 70%);
+  box-shadow: 0 0 0 1px rgba(146, 221, 255, 0.15), 0 0 16px -10px rgba(143, 221, 255, 0.58);
   font-family: var(--title-font);
-  font-size: clamp(1.1rem, 2.4vw, 1.36rem);
+  font-size: clamp(0.92rem, 1.95vw, 1.06rem);
   font-weight: 800;
   letter-spacing: 0.08em;
   color: #ccedff;
-  text-shadow: 0 0 10px rgba(99, 196, 255, 0.2);
-  grid-area: left;
-  align-self: end;
+  text-shadow: 0 0 8px rgba(99, 196, 255, 0.24);
+  grid-area: rank;
+  align-self: center;
 }
 
 .pes6-ranking-player,
@@ -1046,18 +1050,19 @@ summary:focus-visible,
 }
 
 .pes6-ranking-stats {
-  grid-area: left;
-  align-self: start;
+  grid-area: titles;
+  align-self: center;
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.04rem;
+  flex-direction: row;
+  align-items: baseline;
+  justify-content: flex-end;
+  gap: 0.28rem;
+  white-space: nowrap;
   color: rgba(226, 241, 255, 0.9);
   font-size: 0.74rem;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
+  letter-spacing: 0.06em;
   line-height: 1.05;
-  margin-top: 0.08rem;
+  margin-top: 0;
 }
 
 .pes6-ranking-panel,
@@ -1128,7 +1133,7 @@ summary:focus-visible,
 
 .pes6-ranking-total,
 .rankingTotal {
-  font-size: clamp(1.35rem, 3.6vw, 1.72rem);
+  font-size: clamp(1.18rem, 2.9vw, 1.34rem);
   font-weight: 900;
   letter-spacing: 0.02em;
   color: #ecf7ff;
@@ -1138,16 +1143,18 @@ summary:focus-visible,
 .pes6-ranking-total-label,
 .rankingMeta {
   color: rgba(190, 216, 235, 0.88);
-  font-size: 0.64rem;
-  letter-spacing: 0.14em;
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
   font-weight: 700;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
 
 .pes6-ranking {
   border-radius: 20px;
-  border-color: rgba(119, 210, 255, 0.45);
+  border-color: rgba(119, 210, 255, 0.5);
   background: linear-gradient(180deg, rgba(15, 33, 58, 0.94), rgba(8, 19, 36, 0.96));
-  box-shadow: 0 0 0 1px rgba(119, 210, 255, 0.14), 0 0 22px -13px rgba(119, 210, 255, 0.48), 0 16px 28px rgba(0, 0, 0, 0.34);
+  box-shadow: 0 0 0 1px rgba(119, 210, 255, 0.2), 0 0 24px -14px rgba(119, 210, 255, 0.54), 0 16px 28px rgba(0, 0, 0, 0.34);
   padding: 1.1rem;
 }
 
@@ -1169,12 +1176,18 @@ summary:focus-visible,
 .pes6-ranking-row .rankingBtn {
   grid-area: btn;
   align-self: center;
-  min-width: 116px;
+  width: 124px;
   min-height: 36px;
   padding-inline: 0.95rem;
   border-color: rgba(119, 210, 255, 0.5);
   background: linear-gradient(180deg, rgba(16, 33, 58, 0.94), rgba(10, 21, 39, 0.94));
   box-shadow: 0 0 0 1px rgba(119, 210, 255, 0.2), 0 0 14px -11px rgba(119, 210, 255, 0.44);
+}
+
+.pes6-ranking-row .pes6-ranking-toggle > span:first-child,
+.pes6-ranking-row .rankingBtn > span:first-child {
+  display: inline-block;
+  white-space: nowrap;
 }
 
 .pes6-ranking-row .pes6-ranking-toggle:hover,
@@ -1183,50 +1196,61 @@ summary:focus-visible,
   box-shadow: 0 0 0 1px rgba(150, 223, 255, 0.28), 0 0 18px -10px rgba(150, 223, 255, 0.42);
 }
 
-@media (max-width: 420px) {
+@media (max-width: 480px) {
   .pes6-ranking-header,
   .rankingHeaderRow {
-    grid-template-columns: minmax(0, 1fr) auto;
-    grid-template-areas:
-      "left name"
-      "meta btn";
-    grid-auto-rows: auto;
-    row-gap: 8px;
-    column-gap: 10px;
+    grid-template-columns: 48px minmax(0, 1fr) auto 108px;
+    grid-template-areas: "rank name titles btn";
+    gap: 0.5rem;
   }
 
   .pes6-ranking-position,
   .rankingPos {
-    grid-area: left;
-    align-self: center;
+    width: 48px;
+    height: 48px;
+    font-size: 0.82rem;
   }
 
   .pes6-ranking-player,
   .rankingName {
     grid-area: name;
-    align-self: center;
-    font-size: 1.04rem;
+    font-size: 0.96rem;
   }
 
   .pes6-ranking-stats,
   .rankingMeta {
-    grid-area: meta;
-    margin-top: 0;
-    font-size: 0.68rem;
-    opacity: 0.9;
+    font-size: 0.62rem;
+    gap: 0.2rem;
   }
 
   .pes6-ranking-toggle,
   .rankingBtn {
     grid-area: btn;
-    justify-self: end;
-    min-width: 114px;
-    padding-inline: 0.85rem;
-    font-size: 0.66rem;
+    width: 108px;
+    min-width: 108px;
+    min-height: 34px;
+    padding-inline: 0.6rem;
+    font-size: 0.61rem;
   }
 
   .pes6-ranking-row {
     padding: 14px;
+  }
+}
+
+@media (max-width: 360px) {
+  .pes6-ranking-header,
+  .rankingHeaderRow {
+    grid-template-columns: 48px minmax(0, 1fr) auto;
+    grid-template-areas:
+      "rank name titles"
+      "rank btn btn";
+    row-gap: 0.48rem;
+  }
+
+  .pes6-ranking-toggle,
+  .rankingBtn {
+    justify-self: end;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Resolver la superposición entre el número de títulos y el `#rank` en la sección `RANKING DE TÍTULOS` manteniendo la estética azul gamer y sin tocar HTML/JS/data. 
- Hacer que cada fila quede ordenada y legible en mobile y desktop conservando la tipografía y los logos del sitio. 

### Description
- Reorganicé el layout de fila usando CSS Grid en los selectores existentes ` .pes6-ranking-header`, `.rankingHeaderRow`, `.pes6-ranking-position` / `.rankingPos`, `.pes6-ranking-player` / `.rankingName`, `.pes6-ranking-stats` / `.rankingMeta` y `.pes6-ranking-toggle` / `.rankingBtn` para definir 4 columnas: badge (56px), nombre (flex), conteo de títulos (auto, `nowrap`) y botón (ancho fijo). 
- Transformé el rank en un `badge` circular centrado (`display:grid; place-items:center`) con tamaño fijo (`56px` desktop / `48px` mobile) y ajusté tipografías y sombras para un glow competitivo sutil; el conteo de títulos usa `white-space: nowrap` y el nombre es el único campo con `overflow: hidden` + `text-overflow: ellipsis`. 
- Forcé un ancho fijo para la columna del botón (`width:124px` / `108px` en mobile) y añadí reglas que evitan que el botón se achique o se corte; añadí un fallback para pantallas extremadamente angostas (`<=360px`) donde el botón puede bajar a una segunda línea si es estrictamente necesario. 
- Eliminé la dependencia de posicionamientos que causaban superposición al reasignar áreas de grid y centrar/alinear con `align-items:center`, `gap` consistente y `overflow:hidden` solo en el nombre; además añadí transiciones y hover más luminoso sin neon excesivo. 
- Todos los cambios se limitaron a `styles-v2.css` (no se crearon ni renombraron clases ni se tocaron `index.html`, `app.js` ni datos). 

### Testing
- Ejecuté búsqueda de selectores y referencias con `rg -n "ranking|titulo|títulos|rank|detail|detalle"` para verificar localizaciones y confirmar que solo `styles-v2.css` fue modificado (éxito). 
- Revisé el diff con `git diff -- styles-v2.css` y verifiqué que el cambio afectó únicamente a `styles-v2.css` (éxito). 
- Verifiqué el estado del repo con `git status --short` (éxito). 
- Puse un servidor local con `python3 -m http.server` y observé peticiones a `index.html`, `styles-v2.css` y `app.js` en los logs (servidor y assets servidos correctamente); intenté capturas automáticas con Playwright para mobile/desktop pero las pruebas de captura fallaron por el estado oculto del tab en la automatización del entorno (intentos de screenshot fallidos).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c8627224c8332b5d2095569c7e3e0)