### PR TITLE
Ajusta layout visual del ranking de títulos en styles-v2.css

### DIFF
--- a/styles-v2.css
+++ b/styles-v2.css
@@ -1003,10 +1003,14 @@ summary:focus-visible,
 .pes6-ranking-header,
 .rankingHeaderRow {
   display: grid;
-  grid-template-columns: 56px minmax(0, 1fr) auto 124px;
-  grid-template-areas: "rank name titles btn";
+  grid-template-columns: 80px minmax(0, 1fr) 124px;
+  grid-template-rows: auto auto;
+  grid-template-areas:
+    "rank name btn"
+    "rank titles btn";
   align-items: center;
-  gap: 0.75rem;
+  column-gap: 0.85rem;
+  row-gap: 0.18rem;
 }
 
 .pes6-ranking-position,
@@ -1017,52 +1021,64 @@ summary:focus-visible,
 
 .pes6-ranking-position,
 .rankingPos {
-  width: 56px;
-  height: 56px;
-  display: grid;
-  place-items: center;
-  border-radius: 999px;
-  border: 1px solid rgba(146, 221, 255, 0.54);
-  background: radial-gradient(circle at 35% 30%, rgba(143, 221, 255, 0.27), rgba(17, 35, 58, 0.97) 70%);
-  box-shadow: 0 0 0 1px rgba(146, 221, 255, 0.15), 0 0 16px -10px rgba(143, 221, 255, 0.58);
+  width: 80px;
+  min-height: 66px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  position: relative;
   font-family: var(--title-font);
-  font-size: clamp(0.92rem, 1.95vw, 1.06rem);
-  font-weight: 800;
-  letter-spacing: 0.08em;
+  font-size: clamp(2.05rem, 4.4vw, 2.45rem);
+  font-weight: 900;
+  letter-spacing: 0.03em;
   color: #ccedff;
-  text-shadow: 0 0 8px rgba(99, 196, 255, 0.24);
+  text-shadow: 0 3px 10px rgba(71, 179, 255, 0.32);
   grid-area: rank;
-  align-self: center;
+  align-self: stretch;
+}
+
+.pes6-ranking-position::after,
+.rankingPos::after {
+  content: "";
+  position: absolute;
+  left: 2px;
+  right: 18px;
+  bottom: 6px;
+  height: 12px;
+  background: radial-gradient(ellipse at center, rgba(126, 216, 255, 0.44) 0%, rgba(126, 216, 255, 0.14) 55%, rgba(126, 216, 255, 0) 100%);
+  filter: blur(4px);
+  opacity: 0.88;
+  pointer-events: none;
 }
 
 .pes6-ranking-player,
 .rankingName {
   grid-area: name;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   font-size: clamp(1.08rem, 2.7vw, 1.34rem);
   font-weight: 800;
-  letter-spacing: 0.07em;
+  line-height: 1.16;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
   text-shadow: 0 0 10px rgba(99, 196, 255, 0.12);
 }
 
 .pes6-ranking-stats {
   grid-area: titles;
-  align-self: center;
-  display: flex;
-  flex-direction: row;
-  align-items: baseline;
-  justify-content: flex-end;
-  gap: 0.28rem;
+  align-self: start;
+  display: block;
   white-space: nowrap;
-  color: rgba(226, 241, 255, 0.9);
-  font-size: 0.74rem;
-  letter-spacing: 0.06em;
-  line-height: 1.05;
-  margin-top: 0;
+  color: rgba(187, 214, 235, 0.84);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  line-height: 1.12;
+  margin-top: 0.28rem;
 }
 
 .pes6-ranking-panel,
@@ -1177,6 +1193,7 @@ summary:focus-visible,
   grid-area: btn;
   align-self: center;
   width: 124px;
+  min-width: 124px;
   min-height: 36px;
   padding-inline: 0.95rem;
   border-color: rgba(119, 210, 255, 0.5);
@@ -1199,28 +1216,45 @@ summary:focus-visible,
 @media (max-width: 480px) {
   .pes6-ranking-header,
   .rankingHeaderRow {
-    grid-template-columns: 48px minmax(0, 1fr) auto 108px;
-    grid-template-areas: "rank name titles btn";
-    gap: 0.5rem;
+    grid-template-columns: 64px minmax(0, 1fr) 108px;
+    grid-template-rows: auto auto;
+    grid-template-areas:
+      "rank name btn"
+      "rank titles btn";
+    column-gap: 0.6rem;
+    row-gap: 0.14rem;
   }
 
   .pes6-ranking-position,
   .rankingPos {
-    width: 48px;
-    height: 48px;
-    font-size: 0.82rem;
+    width: 64px;
+    min-height: 56px;
+    font-size: clamp(1.78rem, 7.5vw, 2.1rem);
+  }
+
+  .pes6-ranking-position::after,
+  .rankingPos::after {
+    bottom: 4px;
+    height: 10px;
+    right: 10px;
   }
 
   .pes6-ranking-player,
   .rankingName {
     grid-area: name;
     font-size: 0.96rem;
+    line-height: 1.13;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    line-clamp: 2;
+    overflow: hidden;
   }
 
   .pes6-ranking-stats,
   .rankingMeta {
-    font-size: 0.62rem;
-    gap: 0.2rem;
+    font-size: 0.61rem;
+    margin-top: 0.22rem;
   }
 
   .pes6-ranking-toggle,
@@ -1241,16 +1275,14 @@ summary:focus-visible,
 @media (max-width: 360px) {
   .pes6-ranking-header,
   .rankingHeaderRow {
-    grid-template-columns: 48px minmax(0, 1fr) auto;
-    grid-template-areas:
-      "rank name titles"
-      "rank btn btn";
-    row-gap: 0.48rem;
+    grid-template-columns: 58px minmax(0, 1fr) 98px;
   }
 
   .pes6-ranking-toggle,
   .rankingBtn {
-    justify-self: end;
+    width: 98px;
+    min-width: 98px;
+    padding-inline: 0.52rem;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Mejorar la presentación del bloque “RANKING DE TÍTULOS” para que el número de posición sea un texto grande (p. ej. `#1`) sin fondo/badge, mostrar el nombre del jugador completo (wrap hasta 2 líneas en móvil), y colocar la cantidad de títulos debajo del nombre con jerarquía visual más suave.
- Mantener el botón `VER DETALLE` a la derecha, centrado verticalmente, sin modificar HTML/JS ni tipografía global.

### Description
- Reorganicé la fila del ranking a una grid de 3 columnas y 2 filas internas usando los selectores reales `.pes6-ranking-header` / `.rankingHeaderRow` para producir las áreas `rank`, `name`, `titles` y `btn` en dos filas.
- Reemplacé el estilo de badge circular en `.pes6-ranking-position` / `.rankingPos` por un número grande (aumenté `font-size` y `font-weight`), eliminé bordes/fondos circulares y añadí un `::after` que crea un glow/halo inferior suavizado.
- Hice que `.pes6-ranking-player` / `.rankingName` permita wrap (`white-space: normal`, `overflow-wrap`) y ajusté `line-height` para evitar truncados con ellipsis en desktop; en móvil se aplica `-webkit-line-clamp: 2` para limitar a 2 líneas sin forzar `...` en desktop.
- Moví y restilé `.pes6-ranking-stats` / `.rankingMeta` para que aparezca debajo del nombre con tamaño reducido y color más suave; aseguré que el botón `.pes6-ranking-toggle` / `.rankingBtn` tenga ancho fijo (`min-width`) y se mantenga a la derecha sin encogerse.
- Ajusté breakpoints responsive (`@media (max-width:480px)` y `@media (max-width:360px)`) para reducir el ancho del rank, conservar su jerarquía y reducir padding del botón en pantallas pequeñas.
- Cambios aplicados únicamente en `styles-v2.css` y limitados a layout/estilos relacionados con el ranking (selectores: `.pes6-ranking-header`, `.rankingHeaderRow`, `.pes6-ranking-position`, `.rankingPos`, `.pes6-ranking-player`, `.rankingName`, `.pes6-ranking-stats`, `.rankingMeta`, `.pes6-ranking-toggle`, `.rankingBtn`, `.pes6-ranking-row`).

### Testing
- Ejecuté búsqueda de selectores y referencias con `rg -n` sobre `styles-v2.css` e `index.html`/`app.js` para confirmar los selectores afectados, y las búsquedas devolvieron las ubicaciones esperadas (éxito).
- Revisé el diff de `styles-v2.css` para validar que los cambios quedaron limitados al layout del ranking (revisión de diff satisfactoria).
- Levanté un servidor local con `python3 -m http.server` y comprobé `curl -I` a `index.html` obteniendo `HTTP/1.0 200 OK` (servidor disponible).
- Intentos automatizados de captura con Playwright: Chromium falló en este entorno con `SIGSEGV` (fallo de browser en entorno), Firefox tuvo timeouts en intentos iniciales pero finalmente se generaron capturas full-page desktop y mobile (capturas producidas correctamente), por lo que verificación visual fue posible.
- En resumen: búsquedas y diff OK; servidor y capturas generadas (con nota de fallo inicial en Chromium en este entorno).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c891d69908332bbb58172cab61c6d)