### PR TITLE
style: unify Historial visual treatment with Ranking cards

### DIFF
--- a/app.js
+++ b/app.js
@@ -1082,7 +1082,9 @@ function createHistoryRow(itemMeta, value) {
   const winner = document.createElement("div");
   winner.className = "history-value";
   const safeValue = value && value.trim() !== "" ? value : "POR DEFINIR";
-  const isPending = safeValue.toUpperCase() === "POR DEFINIR";
+  const normalizedValue = safeValue.trim().toUpperCase();
+  const isPending = normalizedValue === "POR DEFINIR";
+  const isLegacy = normalizedValue === "NO EXISTIA";
   winner.textContent = safeValue;
 
   if (isPending) {
@@ -1091,6 +1093,11 @@ function createHistoryRow(itemMeta, value) {
     badge.className = "history-pending-badge";
     badge.textContent = "Pendiente";
     winner.appendChild(badge);
+  }
+
+  if (isLegacy) {
+    row.classList.add("is-legacy");
+    winner.classList.add("is-legacy");
   }
 
   row.append(left, winner);

--- a/styles-v2.css
+++ b/styles-v2.css
@@ -1188,6 +1188,148 @@ summary:focus-visible,
   color: rgba(177, 200, 223, 0.9);
 }
 
+
+/* Historial panel tuned to match ranking visual pack */
+#pes6-history {
+  gap: 0.85rem;
+}
+
+.history-accordion-item {
+  border-radius: 20px;
+  border-color: rgba(119, 210, 255, 0.5);
+  background: linear-gradient(180deg, rgba(15, 33, 58, 0.94), rgba(8, 19, 36, 0.96));
+  box-shadow: 0 0 0 1px rgba(119, 210, 255, 0.2), 0 0 24px -14px rgba(119, 210, 255, 0.5), 0 16px 28px rgba(0, 0, 0, 0.34), inset 0 0 0 1px rgba(145, 219, 255, 0.06);
+  padding: 1.1rem;
+}
+
+.history-accordion-trigger {
+  width: 100%;
+  justify-content: space-between;
+  gap: 0.7rem;
+  border-color: rgba(119, 210, 255, 0.48);
+  background: linear-gradient(180deg, rgba(16, 33, 58, 0.92), rgba(10, 21, 39, 0.92));
+  box-shadow: 0 0 0 1px rgba(119, 210, 255, 0.2), 0 0 14px -11px rgba(119, 210, 255, 0.42);
+}
+
+.history-accordion-trigger > span:first-child {
+  font-family: var(--title-font);
+  letter-spacing: 0.08em;
+}
+
+.history-accordion-panel {
+  border-color: rgba(119, 210, 255, 0.28);
+  background: linear-gradient(180deg, rgba(9, 20, 36, 0.9), rgba(6, 13, 24, 0.9));
+  box-shadow: inset 0 0 0 1px rgba(145, 219, 255, 0.06);
+}
+
+.history-section {
+  border-color: rgba(119, 210, 255, 0.35);
+  background: linear-gradient(180deg, rgba(12, 27, 48, 0.9), rgba(7, 17, 32, 0.92));
+  box-shadow: 0 0 0 1px rgba(119, 210, 255, 0.13), 0 0 16px -13px rgba(119, 210, 255, 0.42), inset 0 0 0 1px rgba(145, 219, 255, 0.05);
+  padding: 0.9rem;
+}
+
+.history-section + .history-section {
+  margin-top: 0.75rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(145, 219, 255, 0.14);
+}
+
+.history-section h4 {
+  margin-bottom: 0.72rem;
+  font-family: var(--title-font);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 243, 255, 0.95);
+  text-shadow: 0 0 9px rgba(99, 196, 255, 0.2);
+}
+
+.history-row {
+  position: relative;
+  align-items: center;
+  gap: 0.78rem;
+  padding: 0.78rem 0.84rem;
+  border-radius: 15px;
+  border-color: rgba(119, 210, 255, 0.34);
+  background: linear-gradient(180deg, rgba(14, 30, 52, 0.93), rgba(8, 19, 36, 0.94));
+  box-shadow: 0 0 0 1px rgba(119, 210, 255, 0.12), 0 0 14px -12px rgba(119, 210, 255, 0.44), 0 12px 22px rgba(0, 0, 0, 0.28);
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.history-row + .history-row {
+  margin-top: 0.52rem;
+}
+
+.history-row-left {
+  justify-content: flex-start;
+  gap: 0.72rem;
+  min-width: 0;
+}
+
+.history-trophy {
+  width: clamp(50px, 7.1vw, 58px);
+  height: clamp(50px, 7.1vw, 58px);
+  padding: 0.34rem;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(133, 220, 255, 0.26) 0%, rgba(133, 220, 255, 0.12) 44%, rgba(133, 220, 255, 0.03) 70%, transparent 100%);
+  box-shadow: 0 0 0 1px rgba(149, 226, 255, 0.2), inset 0 0 12px rgba(108, 201, 255, 0.14), 0 0 26px -10px rgba(99, 196, 255, 0.6);
+  filter: drop-shadow(0 0 18px rgba(99, 196, 255, 0.32));
+  flex-shrink: 0;
+}
+
+.history-label {
+  margin: 0;
+  font-family: var(--title-font);
+  font-size: 0.67rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: rgba(200, 229, 248, 0.92);
+  padding: 0.26rem 0.58rem;
+  border-radius: 999px;
+  border: 1px solid rgba(122, 214, 255, 0.38);
+  background: rgba(105, 194, 255, 0.12);
+  box-shadow: 0 0 0 1px rgba(122, 214, 255, 0.11), 0 0 12px -10px rgba(122, 214, 255, 0.52);
+}
+
+.history-value {
+  min-width: 0;
+  text-align: right;
+  font-size: clamp(0.94rem, 2.2vw, 1.04rem);
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  color: rgba(237, 247, 255, 0.98);
+  text-shadow: 0 0 10px rgba(99, 196, 255, 0.14);
+  overflow-wrap: anywhere;
+}
+
+.history-value.is-pending {
+  text-shadow: none;
+}
+
+.history-row.is-legacy {
+  border-color: rgba(119, 210, 255, 0.24);
+}
+
+.history-row.is-legacy .history-value {
+  opacity: 0.65;
+  text-shadow: none;
+}
+
+.history-row.is-legacy .history-trophy {
+  background: radial-gradient(circle, rgba(133, 220, 255, 0.16) 0%, rgba(133, 220, 255, 0.07) 44%, rgba(133, 220, 255, 0.02) 70%, transparent 100%);
+  box-shadow: 0 0 0 1px rgba(149, 226, 255, 0.12), inset 0 0 10px rgba(108, 201, 255, 0.08), 0 0 18px -11px rgba(99, 196, 255, 0.4);
+  filter: drop-shadow(0 0 14px rgba(99, 196, 255, 0.22));
+}
+
+@media (hover: hover) {
+  .history-row:hover {
+    transform: translateY(-2px);
+    border-color: rgba(160, 228, 255, 0.66);
+    box-shadow: 0 0 0 1px rgba(160, 228, 255, 0.3), 0 0 24px -11px rgba(119, 210, 255, 0.56), 0 14px 25px rgba(0, 0, 0, 0.3);
+  }
+}
+
+
 .pes6-ranking-row .pes6-ranking-toggle,
 .pes6-ranking-row .rankingBtn {
   grid-area: btn;
@@ -1270,6 +1412,17 @@ summary:focus-visible,
   .pes6-ranking-row {
     padding: 14px;
   }
+
+  .history-trophy {
+    width: clamp(52px, 15vw, 56px);
+    height: clamp(52px, 15vw, 56px);
+  }
+
+  .history-label {
+    font-size: 0.62rem;
+    padding: 0.24rem 0.5rem;
+  }
+
 }
 
 @media (max-width: 360px) {


### PR DESCRIPTION
### Motivation
- Unificar la estética del panel `Historial` con la del `Ranking de títulos` para que ambos módulos pertenezcan al mismo paquete visual (mismo fondo azul oscuro, bordes cian suaves, glow controlado y spacing consistente).
- Dar más protagonismo a los trofeos y hacer que cada fila/card del historial se perciba como una "tarjeta premio" sin tocar textos, lógica ni assets.
- Mantener responsive/mobile y aplicar la familia tipográfica gamer ya usada en `Ranking`, usando únicamente `styles-v2.css` y una pequeña marca presentacional en el render para el estado especial `NO EXISTIA`.

### Description
- Añadidos estilos en `styles-v2.css` para el panel `#pes6-history`, acorde al look del ranking: bordes, gradientes verticales sutiles, glow exterior e inner glow, padding y bordes redondeados para acorde a las cards de ranking.
- Restyling de las filas/cards de campeón en `styles-v2.css` para que parezcan "premio": mayor sombra/borde, hover lift de 2px y aumento de glow en dispositivos con `:hover`, y badges pill para la etiqueta de división/label.
- Incremento de protagonismo del trofeo mediante `history-trophy` (tamaño mayor, badge circular/halo suave y pseudo-efectos de luz cian controlada), incluyendo ajustes específicos para mobile.
- Añadida tipografía y tracking gamer a encabezados y labels (`--title-font`) y mayor peso/contraste para el nombre del campeón para reforzar jerarquía visual.
- Implementado un estado visual «apagado» para entradas `NO EXISTIA` a través de una clase `is-legacy` (CSS: opacidad reducida, sin glow y halo de trofeo más tenue) y marcado presentacional desde el renderer.
- Cambio mínimo en `app.js`: normalización de la cadena de ganador en `createHistoryRow` y adición de la clase `is-legacy` cuando el valor es `"NO EXISTIA"` para permitir el styling sin alterar lógica de negocio ni textos.

### Testing
- Ejecutado `git diff --check` para validar diferencias y formato, sin errores detectados (éxito).
- Intento automatizado de verificación visual con Playwright para generar una captura de pantalla falló por un crash de Chromium en el entorno (SIGSEGV), por lo que no se pudo obtener screenshot (fallido por entorno, no por los cambios).
- Intento de servir los archivos con `python -m http.server` y consultarlo vía `curl`/Playwright mostró problemas de conexión/arranque del servidor en este entorno, por lo que la verificación local completa no pudo concluir (fallido por entorno).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c8ecd4da0833289db40c947e8ead9)