### PR TITLE
Rediseño visual de Copas y limpieza de separadores decorativos

### DIFF
--- a/app.js
+++ b/app.js
@@ -759,11 +759,13 @@ backToTopButton.addEventListener("click", () => {
   window.scrollTo({ top: 0, behavior: "smooth" });
 });
 
-function createPalmaresCard(item, winnersKey, winnerLabel) {
+function createPalmaresCard(item, winnersKey, winnerLabel, variant = "default") {
+  const isCupVariant = variant === "cups";
   const card = document.createElement("article");
-  card.className = "palmares-card sl-card";
+  card.className = isCupVariant ? "palmares-card palmares-card-cup" : "palmares-card sl-card";
 
   const title = document.createElement("h4");
+  title.className = isCupVariant ? "palmares-cup-title" : "palmares-card-title";
   title.textContent = item.nombre;
 
   const trophy = document.createElement("img");
@@ -772,17 +774,25 @@ function createPalmaresCard(item, winnersKey, winnerLabel) {
   trophy.alt = `Trofeo ${item.nombre}`;
   trophy.loading = "lazy";
 
-  const winners = document.createElement("ul");
-  winners.className = "palmares-winners";
-
   const winnersList = item[winnersKey].filter((winner) => winner && winner.trim() !== "");
   const safeWinners = winnersList.length ? winnersList : ["A confirmar"];
 
-  safeWinners.forEach((winner) => {
-    const winnerItem = document.createElement("li");
-    winnerItem.textContent = `${winnerLabel}: ${winner}`;
-    winners.appendChild(winnerItem);
-  });
+  const winners = document.createElement(isCupVariant ? "p" : "ul");
+  winners.className = isCupVariant ? "palmares-cup-winner" : "palmares-winners";
+
+  if (isCupVariant) {
+    const winner = safeWinners[0];
+    const winnerUpper = winner.trim().toUpperCase();
+    const isLegacy = winnerUpper === "NO EXISTIA" || winnerUpper === "NO EXISTÍA";
+    winners.textContent = `${winnerLabel}: ${winner}`;
+    winners.classList.add(isLegacy ? "is-muted" : "is-highlight");
+  } else {
+    safeWinners.forEach((winner) => {
+      const winnerItem = document.createElement("li");
+      winnerItem.textContent = `${winnerLabel}: ${winner}`;
+      winners.appendChild(winnerItem);
+    });
+  }
 
   card.appendChild(title);
 
@@ -803,6 +813,7 @@ function renderPalmares() {
 
   const sections = [
     {
+      key: "divisions",
       title: "Campeones por División",
       subtitle: "Últimos campeones (Temporada 23)",
       items: PES6_PALMARES.divisiones,
@@ -810,13 +821,15 @@ function renderPalmares() {
       winnerLabel: "Último campeón"
     },
     {
+      key: "cups",
       title: "Copas",
       subtitle: "Últimos campeones de copas (Temporada 22)",
       items: PES6_PALMARES.copas,
       winnersKey: "campeones",
-      winnerLabel: "Último campeón"
+      winnerLabel: "Ganador / Estado"
     },
     {
+      key: "awards",
       title: "Premios individuales",
       items: PES6_PALMARES.individuales,
       winnersKey: "ganadores",
@@ -827,8 +840,9 @@ function renderPalmares() {
   container.replaceChildren();
 
   sections.forEach((section) => {
+    const isCupsSection = section.key === "cups";
     const block = document.createElement("section");
-    block.className = "palmares-block sl-card";
+    block.className = isCupsSection ? "palmares-block palmares-block-cups" : "palmares-block sl-card";
 
     const heading = document.createElement("h3");
     heading.textContent = section.title;
@@ -842,10 +856,10 @@ function renderPalmares() {
     }
 
     const grid = document.createElement("div");
-    grid.className = "palmares-grid";
+    grid.className = isCupsSection ? "palmares-grid palmares-grid-cups" : "palmares-grid";
 
     section.items.forEach((item) => {
-      grid.appendChild(createPalmaresCard(item, section.winnersKey, section.winnerLabel));
+      grid.appendChild(createPalmaresCard(item, section.winnersKey, section.winnerLabel, section.key));
     });
 
     block.appendChild(grid);

--- a/styles-v2.css
+++ b/styles-v2.css
@@ -63,8 +63,8 @@ body.no-scroll {
   inset: 0;
   z-index: -1;
   pointer-events: none;
-  background: var(--vignette);
-  opacity: 0.92;
+  background: radial-gradient(circle at 50% 24%, rgba(32, 70, 117, 0.1), rgba(1, 5, 10, 0.55) 72%);
+  opacity: 0.82;
 }
 
 .section {
@@ -209,14 +209,7 @@ a {
 }
 
 .sl-divider::after {
-  content: "";
-  position: absolute;
-  left: 6%;
-  right: 6%;
-  bottom: -0.45rem;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--line), transparent);
-  box-shadow: var(--divider-glow), 0 0 14px -10px rgba(88, 201, 255, 0.9);
+  content: none;
 }
 
 @keyframes neonPulse {
@@ -389,14 +382,7 @@ summary:focus-visible,
 }
 
 .hud-separator::after {
-  content: "";
-  position: absolute;
-  left: 6%;
-  right: 6%;
-  bottom: -0.45rem;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--line), transparent);
-  box-shadow: var(--divider-glow), 0 0 14px -10px rgba(88, 201, 255, 0.9);
+  content: none;
 }
 
 
@@ -1614,6 +1600,61 @@ summary:focus-visible,
   border-radius: var(--radius-md);
   background: var(--bg-card);
   padding: 1rem;
+}
+
+
+.palmares-block-cups {
+  border: 0;
+  box-shadow: none;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.palmares-grid-cups {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.9rem, 5vw, 2.8rem);
+}
+
+.palmares-card-cup {
+  width: 100%;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  text-align: center;
+}
+
+.palmares-card-cup .palmares-trophy {
+  width: clamp(90px, 20vw, 110px);
+  height: clamp(90px, 20vw, 110px);
+  margin: 0 auto 0.75rem;
+  filter: drop-shadow(0 0 10px rgba(0, 180, 255, 0.7));
+}
+
+.palmares-cup-title {
+  margin: 0;
+  font-family: var(--title-font);
+  font-size: clamp(1.25rem, 5vw, 1.5rem);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  text-shadow: 0 0 10px rgba(0, 180, 255, 0.8);
+}
+
+.palmares-cup-winner {
+  margin: 0.55rem 0 0;
+  font-size: 0.92rem;
+  letter-spacing: 0.02em;
+}
+
+.palmares-cup-winner.is-highlight {
+  color: #f3f9ff;
+}
+
+.palmares-cup-winner.is-muted {
+  color: #8a95a8;
 }
 
 @media (min-width: 860px) {


### PR DESCRIPTION
### Motivation

- Simplificar la visual de la sección "Copas" para eliminar tarjetas/cajas y mostrar cada copa en ancho completo con separación por espacio en lugar de contenedores visuales.
- Quitar líneas separadoras y efectos de fondo demasiado marcados para lograr un fondo azul oscuro más limpio manteniendo el estilo neon.
- Mantener intacta la lógica y los datos, aplicando solo cambios de estructura HTML/CSS y renderizado visual.

### Description

- Añadida variante de render para Palmarés en `app.js` permitiendo que la sección de copas se renderice con `variant === "cups"` y sin clase de card; se añadió tratamiento específico para el texto de ganador/estado (incluyendo el caso `NO EXISTIA`) en `createPalmaresCard`.
- Actualizada la lista `sections` en `renderPalmares` para marcar la sección de copas con `key: "cups"` y pasar la variante al crear las tarjetas; se cambió la etiqueta para el texto del ganador a `"Ganador / Estado"`.
- Estilos nuevos en `styles-v2.css` para la variante de copas: trofeo grande y centrado (90–110px) con glow azul (`filter: drop-shadow(0 0 10px rgba(0,180,255,0.7))`), título protagonista en mayúsculas con glow, y estado/ganador con clases `is-highlight` / `is-muted` según corresponda.
- Eliminadas las líneas decorativas en el layout general reemplazando los pseudo-elementos de `sl-divider::after` y `hud-separator::after` por `content: none;` y suavizado del fondo `.bg-effects` para un azul oscuro más limpio.

### Testing

- Ejecutada verificación de sintaxis JavaScript con `node --check app.js`, la comprobación finalizó correctamente.
- Levantado un servidor local temporal con `python3 -m http.server 4173` y validado visualmente mediante una captura móvil automatizada con Playwright del flujo: abrir la modal de `PES 6` y la pestaña `Palmarés / Campeones`, la captura se generó correctamente.
- No se modificó ninguna lógica de negocio ni los datos; las pruebas automatizadas realizadas tuvieron éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c91da1a088332be71a6618ba1ec46)