### PR TITLE
Rediseño visual de Campeones por División — layout protagonista

### DIFF
--- a/app.js
+++ b/app.js
@@ -761,12 +761,29 @@ backToTopButton.addEventListener("click", () => {
 
 function createPalmaresCard(item, winnersKey, winnerLabel, variant = "default") {
   const isCupVariant = variant === "cups";
+  const isDivisionVariant = variant === "divisions";
   const card = document.createElement("article");
-  card.className = isCupVariant ? "palmares-card palmares-card-cup" : "palmares-card sl-card";
+  card.className = isCupVariant
+    ? "palmares-card palmares-card-cup"
+    : isDivisionVariant
+      ? "palmares-card palmares-card-division"
+      : "palmares-card sl-card";
 
   const title = document.createElement("h4");
-  title.className = isCupVariant ? "palmares-cup-title" : "palmares-card-title";
-  title.textContent = item.nombre;
+  title.className = isCupVariant
+    ? "palmares-cup-title"
+    : isDivisionVariant
+      ? "palmares-division-title"
+      : "palmares-card-title";
+
+  if (isDivisionVariant) {
+    const divisionNames = ["PRIMERA DIVISIÓN", "SEGUNDA DIVISIÓN", "TERCERA DIVISIÓN", "CUARTA DIVISIÓN"];
+    const match = item.nombre.match(/\d+/);
+    const divisionIndex = match ? Number.parseInt(match[0], 10) - 1 : -1;
+    title.textContent = divisionNames[divisionIndex] ?? item.nombre.toUpperCase();
+  } else {
+    title.textContent = item.nombre;
+  }
 
   const trophy = document.createElement("img");
   trophy.className = "palmares-trophy";
@@ -777,15 +794,23 @@ function createPalmaresCard(item, winnersKey, winnerLabel, variant = "default") 
   const winnersList = item[winnersKey].filter((winner) => winner && winner.trim() !== "");
   const safeWinners = winnersList.length ? winnersList : ["A confirmar"];
 
-  const winners = document.createElement(isCupVariant ? "p" : "ul");
-  winners.className = isCupVariant ? "palmares-cup-winner" : "palmares-winners";
+  const winners = document.createElement(isCupVariant || isDivisionVariant ? "p" : "ul");
+  winners.className = isCupVariant
+    ? "palmares-cup-winner"
+    : isDivisionVariant
+      ? "palmares-division-winner"
+      : "palmares-winners";
 
-  if (isCupVariant) {
+  if (isCupVariant || isDivisionVariant) {
     const winner = safeWinners[0];
-    const winnerUpper = winner.trim().toUpperCase();
-    const isLegacy = winnerUpper === "NO EXISTIA" || winnerUpper === "NO EXISTÍA";
-    winners.textContent = `${winnerLabel}: ${winner}`;
-    winners.classList.add(isLegacy ? "is-muted" : "is-highlight");
+    if (isCupVariant) {
+      const winnerUpper = winner.trim().toUpperCase();
+      const isLegacy = winnerUpper === "NO EXISTIA" || winnerUpper === "NO EXISTÍA";
+      winners.textContent = `${winnerLabel}: ${winner}`;
+      winners.classList.add(isLegacy ? "is-muted" : "is-highlight");
+    } else {
+      winners.textContent = winner;
+    }
   } else {
     safeWinners.forEach((winner) => {
       const winnerItem = document.createElement("li");
@@ -794,16 +819,24 @@ function createPalmaresCard(item, winnersKey, winnerLabel, variant = "default") 
     });
   }
 
-  card.appendChild(title);
+  if (isDivisionVariant) {
+    const content = document.createElement("div");
+    content.className = "palmares-division-content";
+    content.append(title, winners);
+    card.append(content, trophy);
+  } else {
+    card.appendChild(title);
 
-  if (item.subtitulo) {
-    const subtitle = document.createElement("p");
-    subtitle.className = "palmares-subtitle";
-    subtitle.textContent = item.subtitulo;
-    card.appendChild(subtitle);
+    if (item.subtitulo) {
+      const subtitle = document.createElement("p");
+      subtitle.className = "palmares-subtitle";
+      subtitle.textContent = item.subtitulo;
+      card.appendChild(subtitle);
+    }
+
+    card.append(trophy, winners);
   }
 
-  card.append(trophy, winners);
   return card;
 }
 
@@ -841,8 +874,13 @@ function renderPalmares() {
 
   sections.forEach((section) => {
     const isCupsSection = section.key === "cups";
+    const isDivisionsSection = section.key === "divisions";
     const block = document.createElement("section");
-    block.className = isCupsSection ? "palmares-block palmares-block-cups" : "palmares-block sl-card";
+    block.className = isCupsSection
+      ? "palmares-block palmares-block-cups"
+      : isDivisionsSection
+        ? "palmares-block palmares-block-divisions"
+        : "palmares-block sl-card";
 
     const heading = document.createElement("h3");
     heading.textContent = section.title;
@@ -856,7 +894,11 @@ function renderPalmares() {
     }
 
     const grid = document.createElement("div");
-    grid.className = isCupsSection ? "palmares-grid palmares-grid-cups" : "palmares-grid";
+    grid.className = isCupsSection
+      ? "palmares-grid palmares-grid-cups"
+      : isDivisionsSection
+        ? "palmares-grid palmares-grid-divisions"
+        : "palmares-grid";
 
     section.items.forEach((item) => {
       grid.appendChild(createPalmaresCard(item, section.winnersKey, section.winnerLabel, section.key));

--- a/styles-v2.css
+++ b/styles-v2.css
@@ -1603,6 +1603,68 @@ summary:focus-visible,
 }
 
 
+
+.palmares-block-divisions {
+  border: 0;
+  box-shadow: none;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.palmares-grid-divisions {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.palmares-card-division {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(0.9rem, 3vw, 1.8rem);
+  margin: 40px 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+}
+
+.palmares-division-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  min-width: 0;
+}
+
+.palmares-division-title {
+  margin: 0;
+  font-family: var(--title-font);
+  font-size: clamp(1.38rem, 6vw, 1.62rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #f5faff;
+  text-shadow: 0 0 10px rgba(0, 180, 255, 0.7);
+}
+
+.palmares-division-winner {
+  margin: 0;
+  font-size: clamp(0.98rem, 3.6vw, 1.08rem);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #f1f7ff;
+}
+
+.palmares-card-division .palmares-trophy {
+  width: clamp(80px, 20vw, 100px);
+  height: clamp(80px, 20vw, 100px);
+  flex-shrink: 0;
+  filter: drop-shadow(0 0 12px rgba(0, 180, 255, 0.6));
+}
+
+
 .palmares-block-cups {
   border: 0;
   box-shadow: none;


### PR DESCRIPTION
### Motivation
- Hacer que cada división aparezca como un bloque protagonista con título grande, campeón debajo y trofeo a la derecha, manteniendo el glow azul y sin cajas pesadas.
- Eliminar el diseño en tarjetas para las divisiones y mantener sólo separación vertical amplia entre bloques sin alterar la lógica ni los datos.

### Description
- `app.js`: Añadí soporte para la variante `divisions` en `createPalmaresCard(...)`, con clases nuevas `palmares-card-division`, `palmares-division-title`, `palmares-division-winner` y `palmares-division-content`, y mapeo de `División 1..4` a los rótulos protagonistas (`PRIMERA DIVISIÓN`, `SEGUNDA DIVISIÓN`, etc.).
- `app.js`: Cambié la composición para divisiones a una sola fila flex (contenido textual a la izquierda + trofeo a la derecha) y mantuve el tratamiento original para copas y premios.
- `styles-v2.css`: Añadí reglas para `palmares-block-divisions`, `palmares-grid-divisions`, `palmares-card-division` y estilos específicos para título (tipografía de `--title-font`, uppercase, tamaño responsivo y `text-shadow` glow azul), nombre del campeón (semibold, sin cápsula) y trofeo (80–100px aprox. con `filter: drop-shadow(...)`).
- Mantengo los trofeos por división y la fuente/tipografía coherente con el ranking de títulos sin tocar la lógica de datos de `PES6_PALMARES`.

### Testing
- Ejecuté la verificación de sintaxis de `app.js` con `node --check app.js` y la comprobación terminó sin errores (éxito).
- Intenté generar una captura automatizada con Playwright (`mcp__browser_tools__run_playwright_script`) pero el navegador en el entorno falló al iniciar Chromium (SIGSEGV), por lo que no pude producir screenshot visual; el servidor HTTP fue iniciado correctamente para pruebas locales.
- No se modificó la lógica de datos ni los nombres de propiedades, por lo que la renderización de secciones distinta a divisiones permanece intacta.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c9784bb608332bcb30e49c4da585b)