### PR TITLE
Rediseño visual real de palmarés: nuevas clases CSS y corrección de textos en Copas

### DIFF
--- a/app.js
+++ b/app.js
@@ -277,7 +277,7 @@ function getCupCrossingTeamLogoPath(teamData) {
 const overlay = document.getElementById("modal-overlay");
 const modals = [...document.querySelectorAll(".league-modal")];
 const triggers = [...document.querySelectorAll(".modal-trigger")];
-const closeButtons = [...document.querySelectorAll(".close-btn")];
+const closeButtons = [...document.querySelectorAll(".close-btn-fixed")];
 const copyButtons = [...document.querySelectorAll(".copy-btn")];
 const backToTopButton = document.getElementById("back-to-top");
 const pes6Status = document.getElementById("pes6Status");
@@ -762,19 +762,18 @@ backToTopButton.addEventListener("click", () => {
 function createPalmaresCard(item, winnersKey, winnerLabel, variant = "default") {
   const isCupVariant = variant === "cups";
   const isDivisionVariant = variant === "divisions";
+  const isIndividualVariant = variant === "awards";
   const card = document.createElement("article");
   card.className = isCupVariant
-    ? "palmares-card palmares-card-cup"
+    ? "copa-item"
     : isDivisionVariant
-      ? "palmares-card palmares-card-division"
-      : "palmares-card sl-card";
+      ? "division-item"
+      : isIndividualVariant
+        ? "individual-item"
+        : "palmares-card sl-card";
 
   const title = document.createElement("h4");
-  title.className = isCupVariant
-    ? "palmares-cup-title"
-    : isDivisionVariant
-      ? "palmares-division-title"
-      : "palmares-card-title";
+  title.className = "palmares-card-title";
 
   if (isDivisionVariant) {
     const divisionNames = ["PRIMERA DIVISIÓN", "SEGUNDA DIVISIÓN", "TERCERA DIVISIÓN", "CUARTA DIVISIÓN"];
@@ -795,18 +794,14 @@ function createPalmaresCard(item, winnersKey, winnerLabel, variant = "default") 
   const safeWinners = winnersList.length ? winnersList : ["A confirmar"];
 
   const winners = document.createElement(isCupVariant || isDivisionVariant ? "p" : "ul");
-  winners.className = isCupVariant
-    ? "palmares-cup-winner"
-    : isDivisionVariant
-      ? "palmares-division-winner"
-      : "palmares-winners";
+  winners.className = isCupVariant || isDivisionVariant ? "palmares-winner-line" : "palmares-winners";
 
   if (isCupVariant || isDivisionVariant) {
     const winner = safeWinners[0];
     if (isCupVariant) {
       const winnerUpper = winner.trim().toUpperCase();
       const isLegacy = winnerUpper === "NO EXISTIA" || winnerUpper === "NO EXISTÍA";
-      winners.textContent = `${winnerLabel}: ${winner}`;
+      winners.textContent = isLegacy ? "Estado: NO EXISTÍA" : `Ganador: ${winner}`;
       winners.classList.add(isLegacy ? "is-muted" : "is-highlight");
     } else {
       winners.textContent = winner;
@@ -821,9 +816,23 @@ function createPalmaresCard(item, winnersKey, winnerLabel, variant = "default") 
 
   if (isDivisionVariant) {
     const content = document.createElement("div");
-    content.className = "palmares-division-content";
+    content.className = "palmares-item-content";
     content.append(title, winners);
     card.append(content, trophy);
+  } else if (isIndividualVariant) {
+    const content = document.createElement("div");
+    content.className = "palmares-item-content";
+    content.append(title);
+
+    if (item.subtitulo) {
+      const subtitle = document.createElement("p");
+      subtitle.className = "palmares-subtitle";
+      subtitle.textContent = item.subtitulo;
+      content.appendChild(subtitle);
+    }
+
+    content.appendChild(winners);
+    card.append(trophy, content);
   } else {
     card.appendChild(title);
 
@@ -859,7 +868,7 @@ function renderPalmares() {
       subtitle: "Últimos campeones de copas (Temporada 22)",
       items: PES6_PALMARES.copas,
       winnersKey: "campeones",
-      winnerLabel: "Ganador / Estado"
+      winnerLabel: "Ganador"
     },
     {
       key: "awards",
@@ -873,14 +882,8 @@ function renderPalmares() {
   container.replaceChildren();
 
   sections.forEach((section) => {
-    const isCupsSection = section.key === "cups";
-    const isDivisionsSection = section.key === "divisions";
     const block = document.createElement("section");
-    block.className = isCupsSection
-      ? "palmares-block palmares-block-cups"
-      : isDivisionsSection
-        ? "palmares-block palmares-block-divisions"
-        : "palmares-block sl-card";
+    block.className = "block-container";
 
     const heading = document.createElement("h3");
     heading.textContent = section.title;
@@ -894,11 +897,7 @@ function renderPalmares() {
     }
 
     const grid = document.createElement("div");
-    grid.className = isCupsSection
-      ? "palmares-grid palmares-grid-cups"
-      : isDivisionsSection
-        ? "palmares-grid palmares-grid-divisions"
-        : "palmares-grid";
+    grid.className = "palmares-grid";
 
     section.items.forEach((item) => {
       grid.appendChild(createPalmaresCard(item, section.winnersKey, section.winnerLabel, section.key));

--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@ Más interacción y estadísticas
 
   <div id="modal-overlay" class="modal-overlay" hidden>
     <section id="pes6-panel" class="league-modal sl-card" role="dialog" aria-modal="true" aria-labelledby="pes6-modal-title" hidden>
-      <button class="close-btn sl-pill" type="button" aria-label="Cerrar panel">×</button>
+      <button class="close-btn-fixed" type="button" aria-label="Cerrar panel">×</button>
       <img class="modal-banner" src="assets/pes6.jpg" alt="PES 6 Banner" />
       <h2 id="pes6-modal-title">PES 6 – INFINITY PATCH</h2>
 
@@ -348,7 +348,7 @@ UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES
     </section>
 
     <section id="sf-panel" class="league-modal sl-card" role="dialog" aria-modal="true" aria-labelledby="kofModalTitle" hidden>
-      <button class="close-btn sl-pill" type="button" aria-label="Cerrar panel">×</button>
+      <button class="close-btn-fixed" type="button" aria-label="Cerrar panel">×</button>
       <img id="kofModalBanner" class="modal-banner" src="assets/kof2002.jpg" alt="King of Fighters 2002 Banner" />
       <h2 id="kofModalTitle">—</h2>
 
@@ -393,7 +393,7 @@ UNA VEZ QUE TERMINES EL REGISTRO NO OLVIDES DEJARNOS TU NOMBRE DE USUARIO DE PES
     </section>
 
     <section id="sistema-panel" class="league-modal sl-card system-modal" role="dialog" aria-modal="true" aria-labelledby="sistema-panel-title" hidden>
-      <button class="close-btn sl-pill" type="button" aria-label="Cerrar panel">×</button>
+      <button class="close-btn-fixed" type="button" aria-label="Cerrar panel">×</button>
       <h2 id="sistema-panel-title">SISTEMA DE LIGA</h2>
 
       <div class="tab-bar system-tab-bar" role="tablist" aria-label="Sistema por liga">

--- a/styles-v2.css
+++ b/styles-v2.css
@@ -280,7 +280,8 @@ a {
 .history-accordion-trigger,
 .cup-tab-btn,
 .tab-btn,
-.close-btn {
+.close-btn,
+.close-btn-fixed {
   transition: border-color 180ms ease, box-shadow 180ms ease, background-color 180ms ease, transform 180ms ease;
 }
 
@@ -341,7 +342,9 @@ a {
 .history-accordion-trigger:hover,
 .history-accordion-trigger:focus-visible,
 .close-btn:hover,
-.close-btn:focus-visible {
+.close-btn:focus-visible,
+.close-btn-fixed:hover,
+.close-btn-fixed:focus-visible {
   border-color: rgba(98, 206, 255, 0.74);
   box-shadow: var(--neon-box-shadow-hover);
 }
@@ -370,6 +373,7 @@ a {
 .system-panel-trigger:focus-visible,
 summary:focus-visible,
 .close-btn:focus-visible,
+.close-btn-fixed:focus-visible,
 .tab-btn:focus-visible,
 .cup-tab-btn:focus-visible,
 .topbar-preview-link:focus-visible {
@@ -1828,4 +1832,85 @@ summary:focus-visible,
   .cup-match-versus {
     align-self: center;
   }
+}
+
+
+.block-container {
+  background: linear-gradient(145deg, rgba(10, 25, 40, 0.95), rgba(8, 18, 30, 0.95));
+  border: 1px solid rgba(0, 180, 255, 0.18);
+  border-radius: 18px;
+  padding: 20px;
+  margin: 30px 0;
+  box-shadow: 0 0 20px rgba(0, 180, 255, 0.18);
+  position: relative;
+}
+
+.palmares-grid {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 16px;
+}
+
+.division-item,
+.copa-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  background: rgba(6, 14, 24, 0.35);
+  border: 1px solid rgba(0, 180, 255, 0.1);
+  border-radius: 14px;
+  padding: 14px;
+}
+
+.palmares-item-content {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.individual-item {
+  background: rgba(6, 14, 24, 0.35);
+  border: 1px solid rgba(0, 180, 255, 0.10);
+  border-radius: 14px;
+  padding: 14px;
+  margin-top: 16px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.individual-item .palmares-trophy {
+  width: 60px;
+  height: 60px;
+  flex-shrink: 0;
+}
+
+.copa-item .palmares-trophy,
+.division-item .palmares-trophy {
+  width: 70px;
+  height: 70px;
+  flex-shrink: 0;
+}
+
+.palmares-card-title {
+  margin: 0;
+}
+
+.palmares-winner-line {
+  margin: 0;
+}
+
+.close-btn-fixed {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 9999;
+  background: rgba(10, 20, 35, 0.8);
+  border: 1px solid rgba(0, 180, 255, 0.25);
+  border-radius: 10px;
+  padding: 8px;
+  color: var(--text-main);
+  line-height: 1;
+  cursor: pointer;
 }


### PR DESCRIPTION
### Motivation
- Aplicar cambios visuales reales en la sección de Palmarés usando clases nuevas y sin reutilizar las antiguas.
- Corregir la presentación de las Copas para mostrar solo `Ganador: <nombre>` o `Estado: NO EXISTÍA` según corresponda.
- Implementar un estilo real para Premios individuales con layout icono-izquierda / texto-derecha y ajustar el botón de cierre para que esté dentro del bloque.

### Description
- Se actualizó la generación del DOM en `app.js` para usar las nuevas clases `block-container`, `copa-item`, `division-item` e `individual-item`, y para cambiar la lógica de texto de copas a mostrar `Ganador: ...` o `Estado: NO EXISTÍA` según el valor.  
- Se reemplazó la selección y binding del botón de cierre en JS por `close-btn-fixed` y se actualizó `index.html` para usar esa clase en los botones de cierre de los modales.  
- Se añadieron reglas CSS en `styles-v2.css` para `block-container`, `copa-item`, `division-item`, `individual-item` y `close-btn-fixed`, incluyendo layout flex para premios individuales con icono de `60px` a la izquierda.  
- Se actualizaron selectores de hover/focus para incluir `close-btn-fixed` y se ajustó la grilla de palmarés para usar `palmares-grid` dentro de `block-container`.

### Testing
- Se verificó la sintaxis JS con `node --check app.js` y no se reportaron errores.  
- Se sirvió el contenido con `python3 -m http.server 4173` y la aplicación cargó correctamente en navegador automatizado.  
- Se ejecutó un script Playwright que abrió la página, abrió el modal PES6, navegó a la pestaña Palmarés y tomó una captura de pantalla para validar visualmente los cambios, y la captura se generó correctamente (`artifacts/palmares-visual-update.png`).  
- Todas las comprobaciones automáticas realizadas (sintaxis y navegación/visualización) finalizaron con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c9ed0fffc83329670e3a76d11d496)