### PR TITLE
Fix mobile scroll lock in PES6 modal/overlay

### DIFF
--- a/styles-v2.css
+++ b/styles-v2.css
@@ -41,12 +41,16 @@
 
 html {
   scroll-behavior: smooth;
+  height: auto;
+  overflow-y: auto;
 }
 
 body {
   margin: 0;
+  height: auto;
   min-height: 100vh;
   overflow-x: hidden;
+  overflow-y: auto;
   font-family: var(--body-font);
   font-size: 16px;
   line-height: 1.7;
@@ -1489,6 +1493,7 @@ summary:focus-visible,
   width: min(980px, 95vw);
   max-height: 93vh;
   overflow: auto;
+  -webkit-overflow-scrolling: touch;
   isolation: isolate;
   z-index: 60;
   padding: clamp(1rem, 3vw, 1.8rem);
@@ -1499,7 +1504,9 @@ summary:focus-visible,
   background: #0b1d3a;
   border-radius: 12px;
   box-shadow: 0 0 20px rgba(0, 140, 255, 0.3);
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   backdrop-filter: none;
 }
 
@@ -1517,6 +1524,11 @@ summary:focus-visible,
   pointer-events: none;
 }
 
+.pes6-crt::before,
+.pes6-crt::after {
+  pointer-events: none;
+}
+
 .league-modal::before,
 .league-modal::after {
   z-index: 0;
@@ -1527,6 +1539,8 @@ summary:focus-visible,
   inset: 0;
   z-index: 50;
   background: rgba(2, 4, 10, 0.72);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .close-btn {


### PR DESCRIPTION
### Motivation
- El modal/overlay de la sección PES6 estaba impidiendo el desplazamiento vertical en móvil tras cambios en el CRT/overlay; hay que permitir scroll táctil sin romper la estética del header o layout de escritorio.
- Evitar que propiedades globales o del overlay bloqueen permanentemente el scroll del `body`/`html` y asegurar que solo se bloquee cuando corresponda (por ejemplo, un modal real abierto). 

### Description
- Actualicé `styles-v2.css` para que `html` y `body` permitan explícitamente `height: auto` y `overflow-y: auto`. 
- Cambié el contenedor del modal para PES6 (`.pes6-crt` / `.league-modal`) a permitir desplazamiento vertical con `overflow-y: auto` y añadí `-webkit-overflow-scrolling: touch` para mejor experiencia táctil. 
- Hice que la `modal-overlay` también soporte `overflow-y: auto` y `-webkit-overflow-scrolling: touch` para no bloquear el documento en móviles. 
- Aseguré que los pseudo-elementos del CRT no capturen eventos táctiles estableciendo `pointer-events: none` en `::before`/`::after` para no interferir con el scroll. 

### Testing
- Levanté un servidor local con `python -m http.server 4173` y verifiqué la página en contexto local sin errores. 
- Ejecuté un script de Playwright en viewport móvil (Chromium, `is_mobile=true`, `has_touch=true`) que abrió el panel `#pes6-panel`, realizó un `scrollBy` y comprobó el cambio de `scrollTop` de `0` a `900`, confirmando que el desplazamiento vertical funciona; también se capturó una captura de pantalla del estado del modal en móvil como evidencia.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ca4bf6378833290370c1e71007252)