### PR TITLE
Agregar botón 🚀 EMPEZAR en información de PES 6

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,6 +312,12 @@ Más interacción y estadísticas
             <p>
               ⚠️ Estos archivos son necesarios para que todos tengamos las mismas plantillas actualizadas y evitar errores online.
             </p>
+
+            <div class="pes6-start-wrapper">
+              <a href="https://chat.whatsapp.com/DvRyA2bxAC67x0ulPQYvCa?mode=gi_t" class="pes6-start-btn" target="_blank" rel="noopener noreferrer">
+                🚀 EMPEZAR
+              </a>
+            </div>
           </div>
         </section>
 

--- a/styles-v2.css
+++ b/styles-v2.css
@@ -1586,6 +1586,33 @@ summary:focus-visible,
   padding-left: 0.62rem;
 }
 
+.pes6-start-wrapper {
+  margin-top: 30px;
+  text-align: center;
+}
+
+.pes6-start-btn {
+  display: inline-block;
+  padding: 14px 28px;
+  border-radius: 10px;
+  border: 1px solid rgba(99, 196, 255, 0.65);
+  font-family: var(--title-font);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-decoration: none;
+  text-transform: uppercase;
+  background: linear-gradient(135deg, #00aaff, #0066ff);
+  color: #fff;
+  box-shadow: 0 0 15px rgba(0, 170, 255, 0.4);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pes6-start-btn:hover,
+.pes6-start-btn:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 0 25px rgba(0, 170, 255, 0.6);
+}
+
 .back-to-top {
   position: fixed;
   right: 0.9rem;
@@ -1819,10 +1846,15 @@ summary:focus-visible,
   .tab-btn,
   .copy-btn,
   .back-to-top,
-  .cup-tab-btn {
+  .cup-tab-btn,
+  .pes6-start-btn {
     width: 100%;
     text-align: center;
     justify-content: center;
+  }
+
+  .pes6-start-wrapper {
+    margin-top: 1.2rem;
   }
 
   .league-card-content,


### PR DESCRIPTION
### Motivation
- Añadir un CTA visible al final del bloque informativo de “PES 6 – Infinity Patch” que lleve a la misma comunidad usada por el sitio sin alterar la estética ni el link existente.
- Mantener compatibilidad móvil y no afectar el comportamiento de scroll dentro del modal.

### Description
- Agregué en `index.html` un bloque HTML al final de la pestaña "Qué necesitás para jugar" con la estructura `<div class="pes6-start-wrapper"><a class="pes6-start-btn" href="https://chat.whatsapp.com/DvRyA2bxAC67x0ulPQYvCa?mode=gi_t">🚀 EMPEZAR</a></div>` usando exactamente la URL que ya tenía la web.
- Añadí estilos en `styles-v2.css` para `.pes6-start-wrapper` y `.pes6-start-btn` que respetan la estética azul/neón y usan transiciones ligeras para hover/focus.
- Extendí la regla responsive existente para que `.pes6-start-btn` ocupe ancho completo en el breakpoint móvil ya definido, sin cambiar otras reglas globales ni introducir transiciones pesadas.

### Testing
- Ejecuté `git diff --check` para detectar problemas de estilo en el diff y no se reportaron errores.
- Verifiqué presencia de los cambios con búsquedas por `rg` en `index.html` y `styles-v2.css` y confirmé las nuevas clases y el href correcto.
- Levanté un servidor estático local con `python3 -m http.server 4173` y ejecuté un script de Playwright que abrió el modal de PES 6, desplazó el contenido y generó una captura (`artifacts/pes6-empezar-btn.png`) para validar visualmente la integración; la prueba automatizada concluyó con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cab1630648332a36bfeb1c6a3606d)