### PR TITLE
Actualizar enlace del botón 🚀 EMPEZAR en sección PES 6

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,7 +314,7 @@ Más interacción y estadísticas
             </p>
 
             <div class="pes6-start-wrapper">
-              <a href="https://chat.whatsapp.com/DvRyA2bxAC67x0ulPQYvCa?mode=gi_t" class="pes6-start-btn" target="_blank" rel="noopener noreferrer">
+              <a href="https://chat.whatsapp.com/FCRsY2UmldYHqpKYdSrmSF?mode=gi_t" class="pes6-start-btn" target="_blank" rel="noopener noreferrer">
                 🚀 EMPEZAR
               </a>
             </div>


### PR DESCRIPTION
### Motivation
- Actualizar el enlace del botón final de la sección informativa `PES 6 – Infinity Patch` para apuntar al nuevo grupo de WhatsApp sin alterar el diseño ni el comportamiento de apertura en nueva pestaña.

### Description
- Reemplacé el `href` del enlace `a.pes6-start-btn` dentro de `index.html` por `https://chat.whatsapp.com/FCRsY2UmldYHqpKYdSrmSF?mode=gi_t` manteniendo `target="_blank"` y `rel="noopener noreferrer"`, sin tocar estilos ni otras secciones.

### Testing
- Verifiqué la presencia y unicidad del enlace con `rg -n "pes6-start-btn|FCRsY2UmldYHqpKYdSrmSF\?mode=gi_t|target=\"_blank\""` y confirmé el diff con `git diff`, luego registré el cambio con `git commit`, todo exitoso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cac56f32c8332ad48560b15cd4733)