### PR TITLE
Agregar bloque ONLINE (OBLIGATORIO) en sección informativa de PES 6

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,6 +313,43 @@ Más interacción y estadísticas
               ⚠️ Estos archivos son necesarios para que todos tengamos las mismas plantillas actualizadas y evitar errores online.
             </p>
 
+            <h3>🌐 ONLINE (OBLIGATORIO)</h3>
+
+            <p>
+              Para jugar todos en el mismo servidor oficial de la liga, deben configurar el online correctamente.
+            </p>
+
+            <h4>1️⃣ Registro en el servidor</h4>
+            <p>
+              Ir a la página:
+              <br>
+              <a href="https://pes6comunidad.trixnodes.com" target="_blank" rel="noopener noreferrer">
+                https://pes6comunidad.trixnodes.com
+              </a>
+              <br><br>
+              En la sección <strong>"Registro"</strong> crear una cuenta en el servidor.
+            </p>
+
+            <h4>2️⃣ Descargar Host Selector</h4>
+            <p>
+              Descargar el selector de host:
+              <br>
+              <a href="https://www.mediafire.com/file/cue87dwh4rt8phs/PES6HostSelector.zip/file" target="_blank" rel="noopener noreferrer">
+                Descargar Host Selector
+              </a>
+            </p>
+
+            <ul>
+              <li>Instalar el programa</li>
+              <li>Ejecutarlo como <strong>Administrador</strong></li>
+              <li>Seleccionar <strong>pes6comunidad</strong></li>
+              <li>Presionar en <strong>Salir</strong></li>
+            </ul>
+
+            <p>
+              ⚠️ Este paso es obligatorio para que todos los jugadores estén conectados al mismo servidor online de Sudaka League.
+            </p>
+
             <div class="pes6-start-wrapper">
               <a href="https://chat.whatsapp.com/FCRsY2UmldYHqpKYdSrmSF?mode=gi_t" class="pes6-start-btn" target="_blank" rel="noopener noreferrer">
                 🚀 EMPEZAR


### PR DESCRIPTION
### Motivation
- Incluir instrucciones obligatorias para conectar al servidor online de la liga dentro de la sección informativa de PES 6 para que todos los jugadores configuren correctamente el online.

### Description
- Inserté un bloque HTML titulado `🌐 ONLINE (OBLIGATORIO)` en `index.html` dentro de la pestaña "Qué necesitás para jugar", ubicado inmediatamente después de los archivos obligatorios (Kit Server y Option File) y antes del botón `🚀 EMPEZAR`.
- El bloque contiene el paso de registro al servidor `https://pes6comunidad.trixnodes.com`, el enlace para descargar el Host Selector desde Mediafire, la lista de pasos de instalación y la advertencia final.
- Mantuvé los atributos de los enlaces como `target="_blank"` y `rel="noopener noreferrer"` y no modifiqué estilos globales, clases existentes ni el botón `🚀 EMPEZAR`.
- Cambio aplicado únicamente en `index.html` (añadidas ~37 líneas HTML) sin tocar CSS o JS.

### Testing
- Verifiqué el diff con `git diff -- index.html` y confirmó la inserción del bloque en la ubicación esperada (éxito).
- Serví el sitio localmente con `python3 -m http.server 4173` y confirmé que los recursos se cargaron correctamente (éxito).
- Ejecuté un script de Playwright que abrió el modal de PES 6 y generó la captura `artifacts/pes6-online-block.png` para validar el render y posicionamiento en pantalla (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cbd46ece0833287639e1bdd86604d)