### PR TITLE
fix: enable and harden update-t24-gesliga workflow triggers

### DIFF
--- a/.github/workflows/update-t24-gesliga.yml
+++ b/.github/workflows/update-t24-gesliga.yml
@@ -1,7 +1,9 @@
-name: Update GesLiga T24
+name: update-t24-gesliga
 
 on:
   workflow_dispatch:
+  push:
+    branches: [ "main" ]
   schedule:
     - cron: "*/30 * * * *"
 
@@ -30,13 +32,21 @@ jobs:
 
       - name: Commit and push if changed
         run: |
-          if git diff --quiet -- public/data/t24/*.json data/t24/*.json; then
+          mapfile -t files < <(find public/data/t24 data/t24 -maxdepth 1 -type f -name '*.json' 2>/dev/null | sort)
+
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No JSON files found to track"
+            exit 0
+          fi
+
+          git add "${files[@]}"
+
+          if git diff --cached --quiet; then
             echo "No changes detected"
             exit 0
           fi
 
           git config user.name "gesliga-bot"
           git config user.email "gesliga-bot@users.noreply.github.com"
-          git add public/data/t24/*.json data/t24/*.json
           git commit -m "chore: update T24 tables from GesLiga"
           git push


### PR DESCRIPTION
### Motivation
- The existing workflow was not appearing/running reliably in Actions and needed explicit triggers, schedule and write permissions so it can run manually, on pushes to `main`, and every 30 minutes while being able to commit generated JSON files.

### Description
- Renamed the workflow name to `update-t24-gesliga` and ensured the header exactly matches the requested block with `workflow_dispatch`, `push` on `main`, `schedule` every 30 minutes, and `permissions.contents: write`.
- Ensured the job uses Node 20 and runs `npm ci` followed by `npm run fetch:gesliga:t24` (keeps the repo's existing fetch step).
- Reworked the commit step to discover JSON files under `public/data/t24` and `data/t24`, stage only those files, skip when no files exist, check that staged changes are present before committing, set `user.name`/`user.email`, and push with the message `chore: update T24 tables from GesLiga`.
- Kept the rest of the job steps intact and hardened the commit logic to avoid no-op commits.

### Testing
- Verified the modified workflow file contents with `sed -n '1,260p' .github/workflows/update-t24-gesliga.yml` and `nl -ba .github/workflows/update-t24-gesliga.yml`, which showed the updated header and steps as expected.
- Confirmed repository working tree was clean with `git status --short` after applying the changes.
- Attempted to trigger the workflow via `gh workflow run update-t24-gesliga.yml` from this environment but it failed because the `gh` CLI is not available (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ccf7e8b0c8332860a3efb51acde83)