### PR TITLE
Corregir rutas de fetch para tablas T24

### DIFF
--- a/app.js
+++ b/app.js
@@ -473,7 +473,13 @@ function createT24TableCard(divisionLabel, rows) {
 }
 
 async function fetchT24DivisionData(key) {
-  const response = await fetch(`${ASSETS_BASE_PATH}/data/t24/${key}.json`, { cache: "no-store" });
+  const T24_FETCH_PATHS = {
+    primera: "data/t24/primera.json",
+    segunda: "data/t24/segunda.json",
+    tercera: "data/t24/tercera.json"
+  };
+
+  const response = await fetch(T24_FETCH_PATHS[key], { cache: "no-store" });
   if (!response.ok) {
     throw new Error(`No se pudo cargar ${key}.json (${response.status})`);
   }


### PR DESCRIPTION
### Motivation
- El frontend no estaba cargando las tablas T24 porque las llamadas `fetch` usaban un prefijo dinámico (`ASSETS_BASE_PATH`) y resolvían rutas incorrectas; se requiere apuntar exactamente a los JSON locales en `data/t24/`.
- El objetivo es usar rutas relativas exactas como `data/t24/primera.json`, `data/t24/segunda.json` y `data/t24/tercera.json` sin cambiar diseño ni workflow.

### Description
- Se modificó la función `fetchT24DivisionData` en `app.js` para usar un mapeo explícito `T24_FETCH_PATHS` que liga `primera`, `segunda` y `tercera` a sus archivos `data/t24/*.json` correspondientes.
- Se eliminó la dependencia de `ASSETS_BASE_PATH` para las peticiones de las tablas T24 y ahora `fetch` usa las rutas relativas exactas solicitadas.
- No se realizaron cambios en la presentación ni en la lógica de renderizado de las tablas, solo se corrigieron las rutas de carga.

### Testing
- Ejecuté `node --check app.js` para validar sintaxis y pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd4274b9c8332b93ab16df49ce241)