### PR TITLE
Add cheerio dependency for GesLiga scraper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "sudaka-league",
       "dependencies": {
-        "cheerio": "^1.0.0"
+        "cheerio": "^1.2.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "fetch:gesliga:t24": "node scripts/fetch-gesliga-t24.mjs"
   },
   "dependencies": {
-    "cheerio": "^1.0.0"
+    "cheerio": "^1.2.0"
   }
 }


### PR DESCRIPTION
### Motivation
- Añadir la dependencia `cheerio` v`^1.2.0` necesaria para el scraper de GesLiga.

### Description
- Actualicé la versión de `cheerio` en `package.json` a `^1.2.0` y actualicé la entrada raíz correspondiente en `package-lock.json` a `^1.2.0`, sin modificar otros archivos.

### Testing
- Ejecuté `npm install cheerio@^1.2.0` y `npm install`, ambos fallaron con `403 Forbidden` al acceder a `https://registry.npmjs.org/cheerio` por restricciones del entorno; verifiqué con `git status --short` y `git diff -- package.json package-lock.json` que sólo se modificaron `package.json` y `package-lock.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cdb148a3c833285b1d00501062429)