### PR TITLE
Usar Clasificacion.aspx pública en scraper GesLiga T24

### DIFF
--- a/scripts/fetch-gesliga-t24.mjs
+++ b/scripts/fetch-gesliga-t24.mjs
@@ -159,8 +159,8 @@ function parseClassificationRows(html) {
   return { rows: [], tableFound: false };
 }
 
-function buildInformeLigaUrl(ligaId) {
-  return `https://www.gesliga.com/InformeLiga.aspx?Liga=${ligaId}&Clasificacion=S&Leyenda=S`;
+function buildClasificacionUrl(ligaId) {
+  return `https://www.gesliga.com/Clasificacion.aspx?Liga=${ligaId}`;
 }
 
 async function fetchHtml(url) {
@@ -203,7 +203,7 @@ async function main() {
   await Promise.all(SOURCES.map((source) => saveDivision(source.key, buildPayload(source, [], startedAt))));
 
   for (const source of SOURCES) {
-    const url = buildInformeLigaUrl(source.ligaId);
+    const url = buildClasificacionUrl(source.ligaId);
     const html = await fetchHtml(url);
 
     const { rows, tableFound } = parseClassificationRows(html);


### PR DESCRIPTION
### Motivation
- Cambiar la fuente del scraper para usar la página pública `Clasificacion.aspx?Liga=<id>` porque `InformeLiga.aspx` requiere login y devuelve HTML de login que rompía el scraping.

### Description
- Reemplacé la construcción de URL de `InformeLiga.aspx` por `Clasificacion.aspx` (`buildClasificacionUrl`) y actualicé su uso en `scripts/fetch-gesliga-t24.mjs`, manteniendo la lógica de parseo, la escritura de JSON en `public/data/t24/*.json` y `data/t24/*.json`, y el comportamiento tolerante a divisiones sin filas.

### Testing
- Intenté ejecutar `node scripts/fetch-gesliga-t24.mjs` pero falló por la dependencia faltante `cheerio` (`ERR_MODULE_NOT_FOUND`) y probé la URL pública con `curl` que devolvió HTTP 403 desde este entorno, por lo que no se pudo verificar la obtención de datos reales aquí.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cefc176c48332a3154868614dabfb)