### PR TITLE
Fix TABLAS T24 data mapping to use gesliga JSON rows

### DIFF
--- a/app.js
+++ b/app.js
@@ -407,6 +407,44 @@ function createT24Cell(tag, text, className = "") {
   return cell;
 }
 
+function splitT24Equipo(equipo = "") {
+  const rawValue = String(equipo || "").trim();
+  if (!rawValue) {
+    return { teamName: "", playerName: "" };
+  }
+
+  const [teamNameRaw = "", playerNameRaw = ""] = rawValue.split(" - ");
+  if (!rawValue.includes(" - ")) {
+    return { teamName: rawValue, playerName: "" };
+  }
+
+  return {
+    teamName: teamNameRaw.trim(),
+    playerName: playerNameRaw.trim()
+  };
+}
+
+function normalizeT24Entry(entry = {}) {
+  const combinedEquipo = typeof entry.equipo === "string" ? entry.equipo : "";
+  const parsedEquipo = splitT24Equipo(combinedEquipo);
+  const teamName = (entry.team || parsedEquipo.teamName || "").trim();
+  const playerName = (entry.player || parsedEquipo.playerName || "").trim();
+
+  return {
+    pos: entry.pos,
+    teamName,
+    playerName,
+    pts: entry.pts,
+    pj: entry.pj,
+    pg: entry.pg,
+    pe: entry.pe,
+    pp: entry.pp,
+    gf: entry.gf,
+    gc: entry.gc,
+    dg: entry.dg
+  };
+}
+
 function createT24TableCard(divisionLabel, rows) {
   const card = document.createElement("article");
   card.className = "t24-card sl-card";
@@ -430,7 +468,8 @@ function createT24TableCard(divisionLabel, rows) {
 
   const tbody = document.createElement("tbody");
 
-  rows.forEach((entry, index) => {
+  rows.forEach((rawEntry, index) => {
+    const entry = normalizeT24Entry(rawEntry);
     const row = document.createElement("tr");
     if (index < 3) {
       row.classList.add("is-top");
@@ -442,8 +481,8 @@ function createT24TableCard(divisionLabel, rows) {
     logoCell.className = "t24-logo-cell";
     const logo = document.createElement("img");
     logo.className = "t24-logo";
-    logo.src = getTeamLogoPath(entry.team || "");
-    logo.alt = `Escudo ${entry.team || "Equipo"}`;
+    logo.src = getTeamLogoPath(entry.teamName || "");
+    logo.alt = `Escudo ${entry.teamName || "Equipo"}`;
     logo.loading = "lazy";
     logo.onerror = () => {
       logo.onerror = null;
@@ -452,8 +491,8 @@ function createT24TableCard(divisionLabel, rows) {
     logoCell.appendChild(logo);
     row.appendChild(logoCell);
 
-    row.appendChild(createT24Cell("td", entry.player || "-", "t24-player"));
-    row.appendChild(createT24Cell("td", entry.team || "-", "t24-team"));
+    row.appendChild(createT24Cell("td", entry.playerName || "-", "t24-player"));
+    row.appendChild(createT24Cell("td", entry.teamName || "-", "t24-team"));
     row.appendChild(createT24Cell("td", String(entry.pts ?? "-")));
     row.appendChild(createT24Cell("td", String(entry.pj ?? "-")));
     row.appendChild(createT24Cell("td", String(entry.pg ?? "-")));
@@ -474,9 +513,9 @@ function createT24TableCard(divisionLabel, rows) {
 
 async function fetchT24DivisionData(key) {
   const T24_FETCH_PATHS = {
-    primera: "data/t24/primera.json",
-    segunda: "data/t24/segunda.json",
-    tercera: "data/t24/tercera.json"
+    primera: toAssetPath("data/gesliga/t24/primera.json"),
+    segunda: toAssetPath("data/gesliga/t24/segunda.json"),
+    tercera: toAssetPath("data/gesliga/t24/tercera.json")
   };
 
   const response = await fetch(T24_FETCH_PATHS[key], { cache: "no-store" });


### PR DESCRIPTION
### Motivation

- La UI de "TABLAS T24" mostraba placeholders y no interpretaba correctamente los JSON generados por el scraper; los archivos usan una estructura con `rows` y un campo `equipo` combinado (`"Equipo - jugador"`) que hay que separar para renderizar correctamente Jugador y Equipo.

### Description

- Añadí `splitT24Equipo` y `normalizeT24Entry` para parsear `equipo` en `teamName` y `playerName`, con fallback seguro cuando no existe el separador. 
- Actualicé el render de la tabla para usar `pos`, `teamName`, `playerName` y las claves de estadísticas (`pts`, `pj`, `pg`, `pe`, `pp`, `gf`, `gc`, `dg`) tal como vienen en los JSON.
- Mantengo la columna de Escudo y el comportamiento de placeholder, pero la búsqueda del escudo ahora usa `teamName` (parte izquierda) en `getTeamLogoPath`/`toAssetPath`.
- Cambié las rutas de fetch a `toAssetPath("data/gesliga/t24/primera.json")`, `.../segunda.json`, `.../tercera.json` para respetar el base path de GitHub Pages.

### Testing

- `node --check app.js` — OK (sin errores de sintaxis).
- Verificación de existencia de los JSON con `test -f public/data/gesliga/t24/primera.json && test -f public/data/gesliga/t24/segunda.json && test -f public/data/gesliga/t24/tercera.json` — OK.
- Serví la app localmente con `python3 -m http.server` y ejecuté un script Playwright que abre el modal PES6 → TABLAS T24 y genera una captura móvil — OK (fetch a `/data/gesliga/t24/*.json` devolvió 200 y la tabla mostró Jugador/Equipo reales sin errores de consola).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cf2d0de388332ab8105ee5621ee70)