### PR TITLE
Corregir rutas de fetch de TABLAS T24 para GitHub Pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -457,7 +457,8 @@ function normalizeT24Entry(entry = {}) {
 }
 
 function createT24TableCard(divisionLabel, data) {
-  const hasRows = Array.isArray(data?.rows) && data.rows.length > 0;
+  const rows = data?.rows || [];
+  const hasRows = rows.length > 0;
   const card = document.createElement("article");
   card.className = "t24-card sl-card";
 
@@ -481,7 +482,7 @@ function createT24TableCard(divisionLabel, data) {
   const tbody = document.createElement("tbody");
 
   if (hasRows) {
-    data.rows.map((rawEntry, index) => {
+    rows.map((rawEntry, index) => {
       const entry = normalizeT24Entry(rawEntry);
       const row = document.createElement("tr");
       if (index < 3) {
@@ -519,7 +520,7 @@ function createT24TableCard(divisionLabel, data) {
     });
   } else {
     const emptyRow = document.createElement("tr");
-    const emptyCell = createT24Cell("td", "Sin datos disponibles");
+    const emptyCell = createT24Cell("td", "Sin datos");
     emptyCell.colSpan = 12;
     emptyRow.appendChild(emptyCell);
     tbody.appendChild(emptyRow);
@@ -532,7 +533,9 @@ function createT24TableCard(divisionLabel, data) {
 }
 
 async function fetchT24DivisionData(key) {
-  const basePath = window.location.pathname.includes("sudaka-league") ? "/sudaka-league" : "";
+  const basePath = window.location.pathname.includes('/sudaka-league')
+    ? '/sudaka-league'
+    : '';
   const T24_FETCH_PATHS = {
     primera: `${basePath}/data/gesliga/t24/primera.json`,
     segunda: `${basePath}/data/gesliga/t24/segunda.json`,
@@ -545,10 +548,9 @@ async function fetchT24DivisionData(key) {
       throw new Error(`No se pudo cargar ${key}.json (${response.status})`);
     }
 
-    const payload = await response.json();
-    if (Array.isArray(payload?.rows)) return payload;
-    if (Array.isArray(payload)) return { rows: payload };
-    return { rows: [] };
+    const data = await response.json();
+    const rows = data.rows || [];
+    return { ...data, rows };
   } catch (error) {
     console.error(`Error en fetch de tabla T24 (${key})`, error);
     throw error;


### PR DESCRIPTION
### Motivation
- Detectar el `basePath` en tiempo de ejecución para que las rutas de datos funcionen correctamente en GitHub Pages y evitar rutas absolutas rotas.
- Asegurar que la UI maneje respuestas sin filas (`rows`) y muestre un mensaje claro cuando no hay datos.

### Description
- Detecto automáticamente el `basePath` usando `window.location.pathname.includes('/sudaka-league') ? '/sudaka-league' : ''` y aplico `${basePath}/data/gesliga/t24/...` en los `fetch` de Primera/Segunda/Tercera.
- Normalizo la respuesta desde `fetch` con `const data = await response.json(); const rows = data.rows || []; return { ...data, rows };` preservando la estructura JSON original.
- Modifico el render para usar `const rows = data?.rows || [];` y mapear `rows` en lugar de `data.rows` para evitar errores si `rows` es undefined.
- Actualizo el estado vacío para mostrar `Sin datos` cuando `rows.length === 0`.

### Testing
- Ejecutado `node --check app.js` y se completó sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cfe0552888332a18b6cc5c08e0293)